### PR TITLE
Add Continents & Countries to CompanionMenu + ItemBuilder#setName & ItemBuilder#setLore replace "&" with "§"

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/core/database/DatabaseConnection.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/database/DatabaseConnection.java
@@ -244,6 +244,7 @@ public class DatabaseConnection {
                             "KEY `fkIdx_38` (`server_id`)," +
                             "CONSTRAINT `FK_37` FOREIGN KEY `fkIdx_38` (`server_id`) REFERENCES `plotsystem_servers` (`id`)" +
                             ");",
+                    "ALTER TABLE plotsystem_countries ADD COLUMN IF NOT EXISTS `continent` enum('europe', 'asia', 'africa', 'oceania', 'south america', 'north america') NOT NULL;",
 
                     // City Projects
                     "CREATE TABLE IF NOT EXISTS `plotsystem_city_projects`" +
@@ -322,8 +323,52 @@ public class DatabaseConnection {
                             "KEY `fkIdx_82` (`difficulty_id`)," +
                             "CONSTRAINT `FK_81` FOREIGN KEY `fkIdx_82` (`difficulty_id`) REFERENCES `plotsystem_difficulties` (`id`)" +
                             ");",
-                    "ALTER TABLE plotsystem_plots ADD COLUMN IF NOT EXISTS outline longtext NOT NULL;"
+                    "ALTER TABLE plotsystem_plots ADD COLUMN IF NOT EXISTS outline longtext NOT NULL;",
 
+                    // API Keys
+                    "CREATE TABLE IF NOT EXISTS `api_keys`" +
+                            "(" +
+                            " `api_key`    varchar(32) NOT NULL ," +
+                            " `created_at` timestamp NOT NULL ," +
+                            "PRIMARY KEY (`api_key`)" +
+                            ");",
+
+                    // Buildteams
+                    "CREATE TABLE IF NOT EXISTS `plotsystem_buildteams`" +
+                            "(" +
+                            " `id`      int NOT NULL AUTO_INCREMENT ," +
+                            " `name`    varchar(45) NOT NULL ," +
+                            " `api_key` varchar(32) NOT NULL ," +
+                            "PRIMARY KEY (`id`)," +
+                            "KEY `FK_132` (`api_key`)," +
+                            "CONSTRAINT `FK_130` FOREIGN KEY `FK_132` (`api_key`) REFERENCES `api_keys` (`api_key`)" +
+                            ");",
+
+                    // Buildteam has Countries
+                    "CREATE TABLE IF NOT EXISTS `plotsystem_buildteam_has_countries`" +
+                            "(" +
+                            " `id`           int NOT NULL ," +
+                            " `country_id`   int NOT NULL ," +
+                            " `buildteam_id` int NOT NULL ," +
+                            "PRIMARY KEY (`id`)," +
+                            "KEY `FK_115` (`buildteam_id`)," +
+                            "CONSTRAINT `FK_113` FOREIGN KEY `FK_115` (`buildteam_id`) REFERENCES `plotsystem_buildteams` (`id`)," +
+                            "KEY `FK_118` (`country_id`)," +
+                            "CONSTRAINT `FK_116` FOREIGN KEY `FK_118` (`country_id`) REFERENCES `plotsystem_countries` (`id`)" +
+                            ");",
+
+                    // Builder Is Reviewer
+                    "CREATE TABLE IF NOT EXISTS `plotsystem_builder_is_reviewer`" +
+                            "(" +
+                            " `id`           int NOT NULL AUTO_INCREMENT ," +
+                            " `builder_uuid` varchar(36) NOT NULL ," +
+                            " `buildteam_id` int NOT NULL ," +
+                            "PRIMARY KEY (`id`)," +
+                            "KEY `FK_138` (`builder_uuid`)," +
+                            "CONSTRAINT `FK_136` FOREIGN KEY `FK_138` (`builder_uuid`) REFERENCES `plotsystem_builders` (`uuid`)," +
+                            "KEY `FK_141` (`buildteam_id`)," +
+                            "CONSTRAINT `FK_139` FOREIGN KEY `FK_141` (`buildteam_id`) REFERENCES `plotsystem_buildteams` (`id`)" +
+                            ");"
             );
         }
     }

--- a/src/main/java/com/alpsbte/plotsystem/core/system/CityProject.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/CityProject.java
@@ -79,12 +79,18 @@ public class CityProject {
         return visible;
     }
 
-    public static List<CityProject> getCityProjects(boolean onlyVisible) {
-        try (ResultSet rs = DatabaseConnection.createStatement("SELECT id FROM plotsystem_city_projects ORDER BY country_id").executeQuery()) {
+    public static List<CityProject> getCityProjects(Country country, boolean onlyVisible) {
+        // if country is not null, only get country's city projects, otherwise load all
+        DatabaseConnection.StatementBuilder statement = DatabaseConnection.createStatement("SELECT id FROM plotsystem_city_projects " + (country == null ? "" : "WHERE country_id = ?") + " ORDER BY country_id");
+        if (country != null) {
+            statement.setValue(country.getID());
+        }
+
+        try (ResultSet rs = statement.executeQuery()) {
             List<CityProject> cityProjects = new ArrayList<>();
             while (rs.next()) {
                 CityProject city = new CityProject(rs.getInt(1));
-                if(city.isVisible() || !onlyVisible) {
+                if (city.isVisible() || !onlyVisible) {
                     cityProjects.add(city);
                 }
             }
@@ -95,6 +101,10 @@ public class CityProject {
             Bukkit.getLogger().log(Level.SEVERE, "A SQL error occurred!", ex);
         }
         return new ArrayList<>();
+    }
+
+    public static List<CityProject> getCityProjects(boolean onlyVisible) {
+        return getCityProjects(null, onlyVisible);
     }
 
     public static void addCityProject(Country country, String name) throws SQLException {

--- a/src/main/java/com/alpsbte/plotsystem/core/system/Country.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/Country.java
@@ -2,6 +2,7 @@ package com.alpsbte.plotsystem.core.system;
 
 import com.alpsbte.plotsystem.core.database.DatabaseConnection;
 import com.alpsbte.plotsystem.utils.Utils;
+import com.alpsbte.plotsystem.utils.enums.Continent;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.ItemStack;
 
@@ -48,11 +49,48 @@ public class Country {
     }
 
     public ItemStack getHead() {
-        return Utils.getItemHead( new Utils.CustomHead(headID));
+        return Utils.getItemHead(new Utils.CustomHead(headID));
+    }
+
+    /**
+     * Get city projects that are inside of this country
+     * <p>
+     * Might be a good idea to put this in CityProject but could work in both classes
+     *
+     * @return CityProjects inside this country
+     */
+    public List<CityProject> getCityProjects() {
+        try (ResultSet rs = DatabaseConnection.createStatement("SELECT id FROM plotsystem_city_projects WHERE country_id = ?").setValue(getID()).executeQuery()) {
+            List<CityProject> cityProjects = new ArrayList<>();
+            while (rs.next()) {
+                cityProjects.add(new CityProject(rs.getInt(1)));
+            }
+
+            DatabaseConnection.closeResultSet(rs);
+            return cityProjects;
+        } catch (SQLException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "A SQL error occurred!", ex);
+        }
+        return new ArrayList<>();
     }
 
     public static List<Country> getCountries() {
         try (ResultSet rs = DatabaseConnection.createStatement("SELECT id FROM plotsystem_countries ORDER BY server_id").executeQuery()) {
+            List<Country> countries = new ArrayList<>();
+            while (rs.next()) {
+                countries.add(new Country(rs.getInt(1)));
+            }
+
+            DatabaseConnection.closeResultSet(rs);
+            return countries;
+        } catch (SQLException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "A SQL error occurred!", ex);
+        }
+        return new ArrayList<>();
+    }
+
+    public static List<Country> getCountries(Continent continent) {
+        try (ResultSet rs = DatabaseConnection.createStatement("SELECT id FROM plotsystem_countries WHERE continent = ? ORDER BY server_id").setValue(continent.databaseEnum).executeQuery()) {
             List<Country> countries = new ArrayList<>();
             while (rs.next()) {
                 countries.add(new Country(rs.getInt(1)));

--- a/src/main/java/com/alpsbte/plotsystem/utils/enums/Continent.java
+++ b/src/main/java/com/alpsbte/plotsystem/utils/enums/Continent.java
@@ -1,0 +1,20 @@
+package com.alpsbte.plotsystem.utils.enums;
+
+import com.alpsbte.plotsystem.utils.io.language.LangPaths;
+
+public enum Continent {
+    EUROPE("europe", LangPaths.Continent.EUROPE),
+    ASIA("asia", LangPaths.Continent.ASIA),
+    AFRICA("africa", LangPaths.Continent.AFRICA),
+    OCEANIA("oceania", LangPaths.Continent.OCEANIA),
+    SOUTH_AMERICA("south america", LangPaths.Continent.SOUTH_AMERICA),
+    NORTH_AMERICA("north america", LangPaths.Continent.NORTH_AMERICA);
+
+    public final String databaseEnum;
+    public final String langPath;
+    Continent(String databaseEnum, String langPath) {
+        this.databaseEnum = databaseEnum;
+        // although LangPath.Continent keys match the enum name, you cannot get the value without reflection
+        this.langPath = langPath;
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/utils/io/language/LangPaths.java
+++ b/src/main/java/com/alpsbte/plotsystem/utils/io/language/LangPaths.java
@@ -27,8 +27,24 @@ public class LangPaths {
         }
     }
 
+    public static final class Country {
+        private static final String COUNTRY = "country.";
+        public static final String COUNTRIES = COUNTRY + "countries";
+    }
+
+    public static final class Continent {
+        private static final String CONTINENT = "continent.";
+        public static final String EUROPE = CONTINENT + "europe";
+        public static final String ASIA = CONTINENT + "asia";
+        public static final String AFRICA = CONTINENT + "africa";
+        public static final String OCEANIA = CONTINENT + "oceania";
+        public static final String SOUTH_AMERICA = CONTINENT + "south-america";
+        public static final String NORTH_AMERICA = CONTINENT + "north-america";
+    }
+
     public static final class CityProject {
         private static final String CITY_PROJECT = "city-project.";
+        public static final String CITIES = CITY_PROJECT + "cities";
         public static final String PROJECT_OPEN = CITY_PROJECT + "open";
         public static final String PROJECT_IN_PROGRESS = CITY_PROJECT + "in-progress";
         public static final String PROJECT_COMPLETED = CITY_PROJECT + "completed";

--- a/src/main/java/com/alpsbte/plotsystem/utils/items/builder/ItemBuilder.java
+++ b/src/main/java/com/alpsbte/plotsystem/utils/items/builder/ItemBuilder.java
@@ -24,6 +24,7 @@
 
 package com.alpsbte.plotsystem.utils.items.builder;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.ItemFlag;
@@ -31,6 +32,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ItemBuilder {
 
@@ -58,12 +60,16 @@ public class ItemBuilder {
     }
 
     public ItemBuilder setName(String name) {
-        itemMeta.setDisplayName(name);
+        // replace & with formatting character §
+        // if non-formatting code is after &, & will not be replaced
+        itemMeta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
         return this;
     }
 
     public ItemBuilder setLore(List<String> lore) {
-        itemMeta.setLore(lore);
+        // replace & with formatting character §
+        // if non-formatting code is after &, & will not be replaced
+        itemMeta.setLore(lore.stream().map(l -> ChatColor.translateAlternateColorCodes('&', l)).collect(Collectors.toList()));
         return this;
     }
 

--- a/src/main/resources/lang/en_GB.yml
+++ b/src/main/resources/lang/en_GB.yml
@@ -39,10 +39,28 @@ plot:
 # | City Projects
 # -----------------------------------------------------
 city-project:
+  cities: "Cities"
   open: "Plots Open"
   in-progress: "Plots In Progress"
   completed: "Plots Completed"
   no-plots-available: "No Plots Available"
+
+# -----------------------------------------------------
+# | Countries
+# -----------------------------------------------------
+country:
+  countries: "Countries"
+
+# -----------------------------------------------------
+# | Continents
+# -----------------------------------------------------
+continent:
+  europe: "Europe"
+  asia: "Asia"
+  africa: "Africa"
+  oceania: "Oceania"
+  south-america: "South America"
+  north-america: "North America"
 
 # -----------------------------------------------------
 # | Difficulty


### PR DESCRIPTION
Makes item definitions easier to color without the use of alt-codes