### PR TITLE
1.21.x Plugin Upgrade (DecentHologram & FancyNpcs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,12 @@
     <version>4.0</version>
 
     <repositories>
+        <!-- TODO: Package our NPC visibility functionality -->
+        <repository>
+            <id>fancyplugins-releases</id>
+            <name>FancyPlugins Repository</name>
+            <url>https://repo.fancyplugins.de/releases</url>
+        </repository>
         <!-- WorldGuard -->
         <repository>
             <id>sk89q-repo</id>
@@ -95,11 +101,11 @@
             <version>1.3.1</version>
             <scope>provided</scope>
         </dependency>
-        <!-- Holographic Displays -->
+        <!-- Decent Hologram -->
         <dependency>
-            <groupId>me.filoghost.holographicdisplays</groupId>
-            <artifactId>holographicdisplays-api</artifactId>
-            <version>3.0.3</version>
+            <groupId>com.github.decentsoftware-eu</groupId>
+            <artifactId>decentholograms</artifactId>
+            <version>2.8.11</version>
             <scope>provided</scope>
         </dependency>
         <!-- Alps Utils -->
@@ -172,7 +178,7 @@
         <dependency>
             <groupId>de.oliver</groupId>
             <artifactId>FancyNpcs</artifactId>
-            <version>2.0.5</version>
+            <version>2.3.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/alpsbte/plotsystem/PlotSystem.java
+++ b/src/main/java/com/alpsbte/plotsystem/PlotSystem.java
@@ -24,13 +24,14 @@
 
 package com.alpsbte.plotsystem;
 
-import com.alpsbte.alpslib.hologram.HolographicDisplay;
+//import com.alpsbte.alpslib.hologram.HolographicDisplay;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
+import com.alpsbte.plotsystem.core.holograms.HologramRegister;
 import com.alpsbte.alpslib.io.YamlFileFactory;
 import com.alpsbte.alpslib.io.config.ConfigNotImplementedException;
 import com.alpsbte.alpslib.utils.AlpsUtils;
 import com.alpsbte.alpslib.utils.head.AlpsHeadEventListener;
 import com.alpsbte.plotsystem.commands.*;
-import com.alpsbte.plotsystem.core.holograms.LeaderboardManager;
 import com.alpsbte.plotsystem.core.system.Builder;
 import com.alpsbte.plotsystem.core.system.plot.Plot;
 import com.alpsbte.plotsystem.core.system.plot.utils.PlotUtils;
@@ -180,8 +181,8 @@ public class PlotSystem extends JavaPlugin {
             }
         });
 
-        HolographicDisplay.registerPlugin(this);
-        LeaderboardManager.initLeaderboards();
+        DecentHologramDisplay.registerPlugin(this);
+        HologramRegister.init();
         PlotUtils.checkPlotsForLastActivity();
         PlotUtils.syncPlotSchematicFiles();
         Utils.ChatUtils.checkForChatInputExpiry();
@@ -221,7 +222,7 @@ public class PlotSystem extends JavaPlugin {
             Bukkit.getConsoleSender().sendMessage(ChatColor.DARK_GRAY + "> " + ChatColor.GRAY + "GitHub: " + ChatColor.WHITE + "https://github.com/AlpsBTE/Plot-System");
             Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + "------------------------------------------------------");
 
-            LeaderboardManager.getLeaderboards().forEach(HolographicDisplay::delete);
+            HologramRegister.getActiveDisplays().forEach(DecentHologramDisplay::delete);
         } else {
             // Unload plots
             for (UUID player : PlotUtils.Cache.getCachedInProgressPlots().keySet()) {
@@ -278,9 +279,8 @@ public class PlotSystem extends JavaPlugin {
          */
         private static boolean checkForRequiredDependencies() {
             PluginManager pluginManager = plugin.getServer().getPluginManager();
-
-            if (!pluginManager.isPluginEnabled("HolographicDisplays")) {
-                missingDependencies.add("HolographicDisplays");
+            if (!pluginManager.isPluginEnabled("DecentHolograms")) {
+                missingDependencies.add("DecentHolograms");
             }
 
             if (!pluginManager.isPluginEnabled("Multiverse-Core")) {

--- a/src/main/java/com/alpsbte/plotsystem/commands/admin/CMD_PReload.java
+++ b/src/main/java/com/alpsbte/plotsystem/commands/admin/CMD_PReload.java
@@ -27,8 +27,8 @@ package com.alpsbte.plotsystem.commands.admin;
 import com.alpsbte.plotsystem.PlotSystem;
 import com.alpsbte.plotsystem.commands.BaseCommand;
 import com.alpsbte.plotsystem.core.database.DatabaseConnection;
-import com.alpsbte.plotsystem.core.holograms.LeaderboardConfiguration;
-import com.alpsbte.plotsystem.core.holograms.LeaderboardManager;
+import com.alpsbte.plotsystem.core.holograms.HologramConfiguration;
+import com.alpsbte.plotsystem.core.holograms.HologramRegister;
 import com.alpsbte.plotsystem.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
@@ -50,9 +50,9 @@ public class CMD_PReload extends BaseCommand {
             PlotSystem.getPlugin().reloadConfig();
             sender.sendMessage(Utils.ChatUtils.getInfoFormat("Successfully reloaded config!"));
 
-            LeaderboardManager.getLeaderboards().forEach(leaderboard -> leaderboard.setPosition(LeaderboardManager
-                    .getPosition((LeaderboardConfiguration) leaderboard)));
-            LeaderboardManager.reloadLeaderboards();
+            HologramRegister.getActiveDisplays().forEach(leaderboard -> leaderboard.setLocation(HologramRegister
+                    .getLocation((HologramConfiguration) leaderboard)));
+            HologramRegister.reload();
             sender.sendMessage(Utils.ChatUtils.getInfoFormat("Successfully reloaded leaderboards!"));
 
             DatabaseConnection.InitializeDatabase();

--- a/src/main/java/com/alpsbte/plotsystem/commands/admin/CMD_SetLeaderboard.java
+++ b/src/main/java/com/alpsbte/plotsystem/commands/admin/CMD_SetLeaderboard.java
@@ -24,10 +24,10 @@
 
 package com.alpsbte.plotsystem.commands.admin;
 
-import com.alpsbte.alpslib.hologram.HolographicDisplay;
 import com.alpsbte.plotsystem.commands.BaseCommand;
-import com.alpsbte.plotsystem.core.holograms.LeaderboardConfiguration;
-import com.alpsbte.plotsystem.core.holograms.LeaderboardManager;
+import com.alpsbte.plotsystem.core.holograms.HologramConfiguration;
+import com.alpsbte.plotsystem.core.holograms.HologramRegister;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
 import com.alpsbte.plotsystem.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -54,7 +54,7 @@ public class CMD_SetLeaderboard extends BaseCommand {
         if (args.length != 1) {
             sendInfo(sender);
             player.sendMessage("§8------- §6§lLeaderboards §8-------");
-            for(HolographicDisplay holo : LeaderboardManager.getLeaderboards()) {
+            for(DecentHologramDisplay holo : HologramRegister.getActiveDisplays()) {
                 player.sendMessage(" §6> §f" + holo.getId());
             }
             player.sendMessage("§8--------------------------");
@@ -62,7 +62,7 @@ public class CMD_SetLeaderboard extends BaseCommand {
         }
 
         // Find leaderboard by name
-        HolographicDisplay leaderboard = LeaderboardManager.getLeaderboards().stream()
+        DecentHologramDisplay leaderboard = HologramRegister.getActiveDisplays().stream()
                 .filter(holo -> holo.getId().equalsIgnoreCase(args[0]))
                 .findFirst()
                 .orElse(null);
@@ -72,7 +72,7 @@ public class CMD_SetLeaderboard extends BaseCommand {
             player.sendMessage(Utils.ChatUtils.getAlertFormat("Leaderboard could not be found!"));
             return true;
         }
-        LeaderboardManager.savePosition(leaderboard.getId(), (LeaderboardConfiguration) leaderboard, getPlayer(sender).getLocation());
+        HologramRegister.saveLocation(leaderboard.getId(), (HologramConfiguration) leaderboard, getPlayer(sender).getLocation());
         player.sendMessage(Utils.ChatUtils.getInfoFormat("Successfully updated hologram location!"));
         player.playSound(player.getLocation(), Utils.SoundUtils.DONE_SOUND,1,1);
         return true;

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/HologramConfiguration.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/HologramConfiguration.java
@@ -24,7 +24,7 @@
 
 package com.alpsbte.plotsystem.core.holograms;
 
-public interface LeaderboardConfiguration {
+public interface HologramConfiguration {
     String getEnablePath();
     String getXPath();
     String getYPath();

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/HologramManager.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/HologramManager.java
@@ -24,11 +24,10 @@
 
 package com.alpsbte.plotsystem.core.holograms;
 
-import com.alpsbte.alpslib.hologram.HolographicDisplay;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
 import com.alpsbte.plotsystem.PlotSystem;
 import com.alpsbte.plotsystem.utils.Utils;
 import com.alpsbte.plotsystem.utils.io.ConfigUtil;
-import me.filoghost.holographicdisplays.api.Position;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -38,32 +37,35 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public final class LeaderboardManager {
-    private static final List<HolographicDisplay> leaderboards = new ArrayList<>();
+public abstract class HologramManager {
+    public static List<DecentHologramDisplay> activeDisplays = new ArrayList<>();
 
-    public static void initLeaderboards() {
-        leaderboards.add(new ScoreLeaderboard());
-        leaderboards.add(new PlotsLeaderboard());
-    }
-
-    public static void reloadLeaderboards() {
-        for (HolographicDisplay leaderboard : leaderboards) {
-            if (PlotSystem.getPlugin().getConfig().getBoolean(((LeaderboardConfiguration) leaderboard).getEnablePath()))
-                for (Player player : Objects.requireNonNull(Bukkit.getWorld(leaderboard.getPosition().getWorldName())).getPlayers()) leaderboard.create(player);
-            else leaderboard.removeAll();
+    public static void reload() {
+        for (DecentHologramDisplay display : activeDisplays) {
+            // Register and create holograms
+            if (PlotSystem.getPlugin().getConfig().getBoolean(((HologramConfiguration) display).getEnablePath())) {
+                display.setEnabled(true);
+                for (Player player : Objects.requireNonNull(Bukkit.getWorld(display.getLocation().getWorld().getName())).getPlayers())
+                    display.create(player);
+            }
+            else {
+                display.setEnabled(false);
+                display.removeAll();
+            }
         }
     }
 
-    public static Position getPosition(LeaderboardConfiguration configPaths) {
+    public static Location getLocation(HologramConfiguration configPaths) {
         FileConfiguration config = PlotSystem.getPlugin().getConfig();
-        return Position.of(Objects.requireNonNull(Utils.getSpawnLocation().getWorld()).getName(),
+
+        return new Location(Objects.requireNonNull(Utils.getSpawnLocation().getWorld()),
                 config.getDouble(configPaths.getXPath()),
                 config.getDouble(configPaths.getYPath()),
                 config.getDouble(configPaths.getZPath())
         );
     }
 
-    public static void savePosition(String id, LeaderboardConfiguration configPaths, Location newLocation) {
+    public static void saveLocation(String id, HologramConfiguration configPaths, Location newLocation) {
         FileConfiguration config = PlotSystem.getPlugin().getConfig();
         config.set(configPaths.getEnablePath(), true);
         config.set(configPaths.getXPath(), newLocation.getX());
@@ -71,17 +73,11 @@ public final class LeaderboardManager {
         config.set(configPaths.getZPath(), newLocation.getZ());
         ConfigUtil.getInstance().saveFiles();
 
-        LeaderboardManager.getLeaderboards().stream().filter(leaderboard -> leaderboard.getId().equals(id)).findFirst()
-                .ifPresent(holo -> holo.setPosition(Position.of(newLocation)));
+        HologramRegister.getActiveDisplays().stream().filter(leaderboard -> leaderboard.getId().equals(id)).findFirst()
+                .ifPresent(holo -> holo.setLocation(newLocation));
     }
 
-    public static class LeaderboardPositionLine extends HolographicDisplay.TextLine {
-        public LeaderboardPositionLine(int position, String username, int score) {
-            super("§e#" + position + " " + (username != null ? "§a" + username : "§8No one, yet") + " §7- §b" + score);
-        }
-    }
-
-    public static List<HolographicDisplay> getLeaderboards() {
-        return leaderboards;
+    public static List<DecentHologramDisplay> getActiveDisplays() {
+        return activeDisplays;
     }
 }

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/HologramRegister.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/HologramRegister.java
@@ -1,0 +1,18 @@
+package com.alpsbte.plotsystem.core.holograms;
+
+// import com.aseanbte.aseanlib.hologram.DecentHologramDisplay;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
+
+public final class HologramRegister extends HologramManager {
+
+    public static void init() {
+        activeDisplays.add(new ScoreLeaderboard());
+        activeDisplays.add(new PlotsLeaderboard());
+    }
+
+    public static class LeaderboardPositionLine extends DecentHologramDisplay.TextLine {
+        public LeaderboardPositionLine(int position, String username, int score) {
+            super("§e#" + position + " " + (username != null ? "§a" + username : "§8No one, yet") + " §7- §b" + score);
+        }
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/PlotsLeaderboard.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/PlotsLeaderboard.java
@@ -24,7 +24,7 @@
 
 package com.alpsbte.plotsystem.core.holograms;
 
-import com.alpsbte.alpslib.hologram.HolographicDisplay;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
 import com.alpsbte.plotsystem.PlotSystem;
 import com.alpsbte.plotsystem.core.system.Builder;
 import com.alpsbte.plotsystem.utils.io.ConfigPaths;
@@ -37,10 +37,11 @@ import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
 
-public class PlotsLeaderboard extends HolographicDisplay implements LeaderboardConfiguration {
+public class PlotsLeaderboard extends DecentHologramDisplay implements HologramConfiguration {
     protected PlotsLeaderboard() {
         super(ConfigPaths.PLOTS_LEADERBOARD, null, false);
-        setPosition(LeaderboardManager.getPosition(this));
+        setLocation(HologramManager.getLocation(this));
+        setEnabled(PlotSystem.getPlugin().getConfig().getBoolean(getEnablePath()));
     }
 
     @Override
@@ -61,7 +62,7 @@ public class PlotsLeaderboard extends HolographicDisplay implements LeaderboardC
             List<Builder.DatabaseEntry<String, Integer>> entries = Builder.getBuildersByCompletedBuilds(10);
             for(int i = 0; i < 10; i++ ) {
                 Builder.DatabaseEntry<String, Integer> entry = i < entries.size() && entries.get(i).getValue() != 0 ? entries.get(i) : null;
-                lines.add(new LeaderboardManager.LeaderboardPositionLine(i + 1, entry != null ? entry.getKey() : null, entry != null ? entry.getValue() : 0));
+                lines.add(new HologramRegister.LeaderboardPositionLine(i + 1, entry != null ? entry.getKey() : null, entry != null ? entry.getValue() : 0));
             }
 
             return lines;

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramContent.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramContent.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright © 2023, ASEAN Build The Earth <bteasean@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package com.alpsbte.plotsystem.core.holograms.connector;
+
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Display contents the hologram will be using.<br/>
+ * [1] ItemStack - Display item at the top of hologram.<br/>
+ * [2] Title - Header message atop the hologram.<br/>
+ * [3] Content - the main content to display.<br/>
+ * [4] Footer - footer line, this is default as a separator line.
+ */
+public interface DecentHologramContent {
+    /**
+     * Display entity as minecraft item.
+     * This will be display at the top of hologram
+     * @return Minecraft ItemStack
+     */
+    ItemStack getItem();
+
+    /**
+     * Title message as String.
+     * @param playerUUID Focused player.
+     * @return The message.
+     */
+    String getTitle(UUID playerUUID);
+
+    /**
+     * Header message as DataLine.
+     * By default, this is using the value from getTitle as a header with a separator line
+     * @param playerUUID Focused player.
+     * @return The DataLine.
+     */
+    List<DecentHologramDisplay.DataLine<?>> getHeader(UUID playerUUID);
+
+    /**
+     * Main content to be written in the hologram
+     * @param playerUUID Focused player.
+     * @return The DataLine.
+     */
+    List<DecentHologramDisplay.DataLine<?>> getContent(UUID playerUUID);
+
+    /**
+     * The footer line at the bottom of the hologram.
+     * By default, this is a separator line.
+     * @param playerUUID Focused player.
+     * @return The DataLine.
+     */
+    List<DecentHologramDisplay.DataLine<?>> getFooter(UUID playerUUID);
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramDisplay.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramDisplay.java
@@ -1,0 +1,376 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright © 2023, ASEAN Build The Earth <bteasean@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package com.alpsbte.plotsystem.core.holograms.connector;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import eu.decentsoftware.holograms.api.holograms.HologramLine;
+import eu.decentsoftware.holograms.api.holograms.HologramPage;
+import eu.decentsoftware.holograms.event.HologramClickEvent;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Wrapper class to use DecentHologram API, this creates and manage hologram per player.
+ * Meaning that individual player can see the hologram personally in multiplayer world.
+ */
+public abstract class DecentHologramDisplay implements DecentHologramContent {
+    public static List<DecentHologramDisplay> activeDisplays = new ArrayList<>();
+    protected final HashMap<UUID, Hologram> holograms = new HashMap<>();
+    public static final String contentSeparator = "§7---------------";
+    private ClickAction clickListener;
+    private final String id;
+    private Location location;
+    private boolean isEnabled;
+
+    /**
+     * Click action which is executed when the player clicks on the hologram on the hologram.
+     */
+    @FunctionalInterface
+    public interface ClickAction {
+        void onClick(@NotNull HologramClickEvent clickEvent);
+    }
+
+    /**
+     * Register hologram listener as DecentHologramListener Class.
+     * @see DecentHologramDisplay#registerPlugin(Plugin)
+     * @param plugin Plugin in use of this library.
+     */
+    public static void registerPlugin(Plugin plugin) {
+        plugin.getServer().getPluginManager().registerEvents(new DecentHologramListener(), plugin);
+    }
+
+    /**
+     * @param id Hologram identifier for creating DecentHologram name, this will later be concatenated as "${player.uuid}-${id}"
+     * @param location The location in a world to create hologram.
+     * @param isEnabled Force enable or disable this hologram on create, this will not register new hologram in the hashmap.
+     */
+    public DecentHologramDisplay(@NotNull String id, Location location, boolean isEnabled) {
+        this.id = id;
+        this.location = location;
+        this.isEnabled = isEnabled;
+        activeDisplays.add(this);
+    }
+
+    /**
+     * Create hologram for player to see.
+     * If the player has correct ViewPermission and hologram is configured enabled,
+     * the hologram will be created
+     * @param player The player that will be able to view this hologram
+     */
+    public void create(Player player) {
+        if(!isEnabled | !this.hasViewPermission(player.getUniqueId())) return;
+        if (this.holograms.containsKey(player.getUniqueId())) {
+            this.reload(player.getUniqueId());
+        } else {
+            Bukkit.getConsoleSender().sendMessage("[DHAPI] Created display ID: " + id + " For player: " + player.getUniqueId());
+            Hologram hologram = DHAPI.createHologram(player.getUniqueId() + "-" + id, location);
+
+            // Exclude all player to view this then allow only player to see
+            hologram.setDefaultVisibleState(false);
+            hologram.setShowPlayer(player);
+
+            this.holograms.put(player.getUniqueId(), hologram);
+            this.reload(player.getUniqueId());
+        }
+    }
+
+    /**
+     * Abstract method to add functionality to whether a player creating this hologram can view it or not.
+     * @param playerUUID Focused player.
+     * @return If true, the hologram will be created for player. Else not.
+     */
+    public abstract boolean hasViewPermission(UUID playerUUID);
+
+    /**
+     * Check if a player can view this hologram.
+     * @param playerUUID Focused player.
+     * @return True if hologram is visible to player.
+     */
+    public boolean isVisible(UUID playerUUID) {
+        return this.holograms.containsKey(playerUUID);
+    }
+
+    public List<DataLine<?>> getHeader(UUID playerUUID) {
+        return Arrays.asList(new ItemLine(this.getItem()), new TextLine(this.getTitle(playerUUID)), new TextLine(contentSeparator));
+    }
+
+    public List<DataLine<?>> getFooter(UUID playerUUID) {
+        return Collections.singletonList(new TextLine(contentSeparator));
+    }
+
+    /**
+     * Re-Write hologram dataLines received by getHeader(), getContent() and getFooter() in order.
+     * @param playerUUID Focused player.
+     */
+    public void reload(UUID playerUUID) {
+        if (!holograms.containsKey(playerUUID)) return;
+        List<DataLine<?>> dataLines = new ArrayList<>();
+
+        List<DataLine<?>> header = getHeader(playerUUID);
+        if (header != null) dataLines.addAll(header);
+
+        List<DataLine<?>> content = getContent(playerUUID);
+        if (content != null) dataLines.addAll(content);
+
+        List<DataLine<?>> footer = getFooter(playerUUID);
+        if (footer != null) dataLines.addAll(footer);
+
+        updateDataLines(holograms.get(playerUUID).getPage(0), 0, dataLines);
+    }
+
+    /**
+     * Call the reload method on all holograms.
+     */
+    public void reloadAll() {
+        for (UUID playerUUID : holograms.keySet()) reload(playerUUID);
+    }
+
+    /**
+     * Remove a hologram assigned to this display from player access.
+     * @param playerUUID Focused player.
+     */
+    public void remove(UUID playerUUID) {
+        if (this.holograms.containsKey(playerUUID)) {
+            DHAPI.removeHologram(playerUUID + "-" + id);
+            this.holograms.get(playerUUID).delete();
+        }
+
+        this.holograms.remove(playerUUID);
+    }
+
+    /**
+     * Remove all assigned hologram this display has,
+     * this still does not remove the display itself
+     */
+    public void removeAll() {
+        List<UUID> playerUUIDs = new ArrayList<>(holograms.keySet());
+        for (UUID playerUUID : playerUUIDs) remove(playerUUID);
+    }
+
+    /**
+     * Delete this display entirely
+     */
+    public void delete() {
+        this.removeAll();
+        this.holograms.clear();
+        activeDisplays.remove(this);
+    }
+
+    /**
+     * Get the identifier from when this hologram is first constructed.
+     * @return ID as String.
+     */
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Get the hologram location.
+     * @return hologram location.
+     */
+    public Location getLocation() {
+        return this.location;
+    }
+    public void setLocation(Location newPosition) {
+        this.location = newPosition;
+        for (UUID playerUUID : holograms.keySet()) holograms.get(playerUUID).setLocation(newPosition);
+
+    }
+
+    /**
+     * Is this hologram enabled.
+     * @return Is enabled.
+     */
+    public boolean isEnabled() {
+        return this.isEnabled;
+    }
+
+    /**
+     * Force set the hologram enabled or disabled.
+     * @param isEnabled If false, the hologram will not be created in any way.
+     */
+    public void setEnabled(boolean isEnabled) { this.isEnabled = isEnabled; }
+
+    /**
+     * Get hologram instance mapped in this display.
+     * @param playerUUID Focused player.
+     * @return Hologram object from DecentHologram plugin.
+     */
+    public Hologram getHologram(UUID playerUUID) {
+        return this.holograms.get(playerUUID);
+    }
+
+    /**
+     * Get all the mapped hologram in this display.
+     * @return HashMap of Hologram by a player UUID.
+     */
+    public HashMap<UUID, Hologram> getHolograms() {
+        return this.holograms;
+    }
+
+    /**
+     * Write a hologram page by any DataLine of type
+     * @param page The hologram page to write
+     * @param startIndex Start line to update
+     * @param dataLines The data item to be write on the page
+     */
+    protected static void updateDataLines(HologramPage page, int startIndex, List<DataLine<?>> dataLines) {
+        int index = startIndex;
+        if (index == 0 && page.getLines().size() > dataLines.size()) {
+            int removeCount = page.getLines().size() - dataLines.size();
+
+            for(int i = 0; i < removeCount; ++i) {
+                int lineIndex = page.getLines().size() - 1;
+                if (lineIndex >= 0) {
+                    DHAPI.removeHologramLine(page, lineIndex);
+                }
+            }
+        }
+
+        for (DataLine<?> data : dataLines) {
+            if (data instanceof TextLine) replaceLine(page, index, ((TextLine) data).getLine());
+            else if (data instanceof ItemLine) replaceLine(page, index, ((ItemLine) data).getLine());
+            index++;
+        }
+
+    }
+
+    /**
+     * Write an index line of a hologram page
+     * @param page The hologram page to write
+     * @param line The index line to write to
+     * @param item any minecraft item as an ItemStack to be inserted
+     */
+    protected static void replaceLine(HologramPage page, int line, ItemStack item) {
+        try {
+            if (page.getLines().size() < line + 1) {
+                DHAPI.addHologramLine(page, item);
+            } else {
+                HologramLine hologramLine = page.getLines().get(line);
+                DHAPI.setHologramLine(hologramLine,  item);
+            }
+        } catch (IllegalArgumentException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "[DHAPI] Trying to set invalid HologramLine ", ex);
+        }
+    }
+
+    /**
+     * Write an index line of a hologram page
+     * @param page The hologram page to write
+     * @param line The index line to write to
+     * @param text The text to be written on
+     */
+    protected static void replaceLine(HologramPage page, int line, String text) {
+        try {
+            if (page.getLines().size() < line + 1) {
+                DHAPI.addHologramLine(page, text);
+            } else {
+                HologramLine hologramLine = page.getLines().get(line);
+                DHAPI.setHologramLine(hologramLine, text);
+            }
+        } catch (IllegalArgumentException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "[DHAPI] Trying to set invalid HologramLine", ex);
+        }
+    }
+
+    /**
+     * Assign a click listener to this hologram, a ClickAction will be call when anyone clicks the hologram.
+     * This should be called right when reloading the hologram
+     * <pre>{@code
+     * @Override
+     * public void reload(UUID playerUUID) {
+     *     super.reload(playerUUID);
+     *     super.setClickListener((clickEvent) -> {});
+     * }}
+     * </pre>
+     * @param clickListener Action callback.
+     */
+    public void setClickListener(@Nullable ClickAction clickListener) {
+        this.clickListener = clickListener;
+    }
+    public @Nullable ClickAction getClickListener() {
+        return this.clickListener;
+    }
+
+    /**
+     * Get activeDisplays in DecentHologramDisplay by ID
+     * @param id The id first used to construct a new DecentHologramDisplay
+     * @return The hologram assigned to id.
+     */
+    public static DecentHologramDisplay getById(String id) {
+        return activeDisplays.stream().filter(holo -> holo.getId().equals(id)).findFirst().orElse(null);
+    }
+
+    /**
+     * DataLine of any type, acts as a text lines per hologram page.
+     * @param <T> DataLine type, this can only be ItemStack as ItemLine or String as TextLine
+     */
+    public interface DataLine<T> { T getLine(); }
+
+    /**
+     * Minecraft ItemStack as DataLine
+     */
+    public static class ItemLine implements DataLine<ItemStack> {
+        private final ItemStack line;
+
+        public ItemLine(ItemStack line) {
+            this.line = line;
+        }
+
+        public ItemStack getLine() {
+            return this.line;
+        }
+    }
+
+    /**
+     * String as DataLine
+     */
+    public static class TextLine implements DataLine<String> {
+        private final String line;
+
+        public TextLine(String line) {
+            this.line = line;
+        }
+
+        public String getLine() {
+            return this.line;
+        }
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramListener.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramListener.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright © 2023, ASEAN Build The Earth <bteasean@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package com.alpsbte.plotsystem.core.holograms.connector;
+
+import eu.decentsoftware.holograms.event.HologramClickEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+import java.util.Objects;
+
+/**
+ * Listener class for DecentHologram.<br/>
+ * This class listened for:<br/>
+ * [1] Create displays everytime a player joined.<br/>
+ * [2] Delete displays when a player quit.<br/>
+ * [3] Re-create and delete displays when a player changes world.<br/>
+ * [4] HologramClickEvent callback to any registered hologram.<br/>
+ * @see PlayerJoinEvent
+ * @see PlayerQuitEvent
+ * @see PlayerChangedWorldEvent
+ * @see HologramClickEvent
+ */
+public class DecentHologramListener implements Listener {
+    public DecentHologramListener() {}
+
+    @EventHandler
+    public void onPlayerJoinEvent(PlayerJoinEvent event) {
+        for (DecentHologramDisplay display : DecentHologramDisplay.activeDisplays) {
+            if (display.getLocation() == null) return;
+            if (Objects.requireNonNull(display.getLocation().getWorld()).getName().equals(event.getPlayer().getWorld().getName()))
+                display.create(event.getPlayer());
+        }
+
+    }
+
+    @EventHandler
+    public void onPlayerQuitEvent(PlayerQuitEvent event) {
+        for (DecentHologramDisplay display : DecentHologramDisplay.activeDisplays) {
+            if (display.getHolograms().containsKey(event.getPlayer().getUniqueId())) display.remove(event.getPlayer().getUniqueId());
+        }
+    }
+
+    @EventHandler
+    public void onPlayerChangedWorldEvent(PlayerChangedWorldEvent event) {
+        for (DecentHologramDisplay display : DecentHologramDisplay.activeDisplays) {
+            if (display.getLocation() == null) return;
+            if (Objects.requireNonNull(display.getLocation().getWorld()).getName().equals(event.getFrom().getName())) display.remove(event.getPlayer().getUniqueId());
+            else if (display.getLocation().getWorld().getName().equals(event.getPlayer().getWorld().getName())) display.create(event.getPlayer());
+        }
+
+    }
+
+    @EventHandler
+    public void onHologramClick(HologramClickEvent event) {
+        for (DecentHologramDisplay display : DecentHologramDisplay.activeDisplays) {
+            if (display.getLocation() == null
+                | display.getClickListener() == null
+                | display.getHologram(event.getPlayer().getUniqueId()) == null) continue;
+            if (display.getHologram(event.getPlayer().getUniqueId()).equals(event.getHologram()))
+                display.getClickListener().onClick(event);
+        }
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramPagedDisplay.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/holograms/connector/DecentHologramPagedDisplay.java
@@ -1,0 +1,263 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright © 2023, ASEAN Build The Earth <bteasean@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package com.alpsbte.plotsystem.core.holograms.connector;
+
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import eu.decentsoftware.holograms.event.HologramClickEvent;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.Collections;
+import java.util.logging.Level;
+
+/**
+ * Extended class to create paged hologram display
+ */
+public abstract class DecentHologramPagedDisplay extends DecentHologramDisplay {
+    public BukkitTask changePageTask = null;
+    private final Plugin plugin;
+    private int pageCount = 1;
+    private int currentPage = 0;
+    private int changeState = 0;
+    private long changeDelay = 0;
+    protected boolean automaticallySkipPage;
+
+    /**
+     * @param id Hologram identifier for creating DecentHologram name, this will later be concatenated as "${player.uuid}-${id}"
+     * @param location The location in a world to create hologram.
+     * @param isEnabled Force enable or disable this hologram on create, this will not register new hologram in the hashmap.
+     * @param plugin Assign a plugin reference and this hologram pages will be automatically turns by a fixed interval.
+     */
+    public DecentHologramPagedDisplay(@NotNull String id, Location location, boolean isEnabled, @NotNull Plugin plugin) {
+        super(id, location, isEnabled);
+        this.plugin = plugin;
+        this.automaticallySkipPage =  true;
+    }
+
+    /**
+     * @param id Hologram identifier for creating DecentHologram name, this will later be concatenated as "${player.uuid}-${id}"
+     * @param location The location in a world to create hologram.
+     * @param isEnabled Force enable or disable this hologram on create, this will not register new hologram in the hashmap.
+     */
+    public DecentHologramPagedDisplay(@NotNull String id, Location location, boolean isEnabled) {
+        super(id, location, isEnabled);
+        this.plugin = null;
+        this.automaticallySkipPage = false;
+    }
+
+    /**
+     * Set a number of pages in this hologram.
+     * @param pageCount Pages size, this should be in sync with how many member page contents has.
+     */
+    public void setPageCount(int pageCount) {
+        this.pageCount = pageCount;
+    }
+
+    @Override
+    public void create(Player player) {
+        if (!super.isEnabled() | !this.hasViewPermission(player.getUniqueId())) return;
+        if (this.holograms.containsKey(player.getUniqueId())) this.reload(player.getUniqueId());
+        else {
+            Bukkit.getLogger().log(Level.INFO, "[DHAPI] Created display ID: " + super.getId() + " For player: " + player.getUniqueId());
+            Hologram hologram = DHAPI.createHologram(player.getUniqueId() + "-" + super.getId(), super.getLocation());
+            for(int i = 1; i <= pageCount; i++) hologram.addPage();
+
+            // Allow only player to see
+            hologram.setDefaultVisibleState(false);
+            hologram.setShowPlayer(player);
+
+            // Put new hologram to hashmap
+            this.holograms.put(player.getUniqueId(), hologram);
+
+            // Write hologram data-lines and assign click listener
+            this.reload(player.getUniqueId());
+            if(!automaticallySkipPage) super.setClickListener(this::assignClickListener);
+            else startChangePageTask(player, hologram);
+        }
+
+    }
+
+
+    @Override
+    public void reload(UUID playerUUID) {
+        if (!holograms.containsKey(playerUUID)) return;
+
+        List<List<DataLine<?>>> header = getPagedHeader(playerUUID);
+        List<List<DataLine<?>>> content = getPagedContent(playerUUID);
+        List<List<DataLine<?>>> footer = getPagedFooter(playerUUID);
+
+        for(int i = 0; i < pageCount; i++) {
+
+            List<DataLine<?>> dataLines = new ArrayList<>();
+
+            if (header != null && header.size() > 1) dataLines.addAll(header.get(i));
+            else if (header != null && header.size() == 1) dataLines.addAll(header.get(0));
+
+            if (content != null && content.size() > 1) dataLines.addAll(content.get(i));
+            else if (content != null && content.size() == 1) dataLines.addAll(content.get(0));
+
+            if (footer != null && footer.size() > 1) dataLines.addAll(footer.get(i));
+            else if (footer != null && footer.size() == 1) dataLines.addAll(footer.get(0));
+
+            updateDataLines(holograms.get(playerUUID).getPage(i), 0, dataLines);
+        }
+
+    }
+
+    /**
+     * getHeader as paged list, the list indexing will be mapped to hologram page one by one.<br/>
+     * If the parent list only have one index, will use the index for every pageCount.
+     * @param playerUUID Focused player.
+     * @return Lists of DataLine, with a parent List being a page indexing.
+     */
+    public List<List<DataLine<?>>> getPagedHeader(UUID playerUUID) {
+        return new ArrayList<>(Collections.singletonList(getHeader(playerUUID)));
+    }
+
+    /**
+     * getContent as paged list, the list indexing will be mapped to hologram page one by one.<br/>
+     * If the parent list only have one index, will use the index for every pageCount.
+     * @param playerUUID Focused player.
+     * @return Lists of DataLine, with a parent List being a page indexing.
+     */
+    public List<List<DataLine<?>>> getPagedContent(UUID playerUUID) {
+        return new ArrayList<>(Collections.singletonList(getContent(playerUUID)));
+    }
+
+    /**
+     * getFooter as paged list, the list indexing will be mapped to hologram page one by one.<br/>
+     * If the parent list only have one index, will use the index for every pageCount.
+     * @param playerUUID Focused player.
+     * @return Lists of DataLine, with a parent List being a page indexing.
+     */
+    public List<List<DataLine<?>>> getPagedFooter(UUID playerUUID) {
+        return new ArrayList<>(Collections.singletonList(getFooter(playerUUID)));
+    }
+
+    /**
+     * Override this function to implement click action of the hologram,
+     * defaulted to calling next page.
+     * @param event Click event callback
+     * @see HologramClickEvent
+     */
+    public void assignClickListener(HologramClickEvent event) {
+        nextPage(event.getPlayer(), event.getHologram());
+    }
+
+    /**
+     * Recursively change pages of this hologram by a fixed interval forever.
+     * @param player Focused player.
+     * @param hologram Focused hologram.
+     */
+    private void startChangePageTask(Player player, Hologram hologram) {
+        // Fixed interval value
+        final long interval = getInterval();
+        changeDelay = interval / contentSeparator.length();
+        changeState = 0;
+
+        // Cancel if no page, and cancel previous task to start anew
+        if(pageCount <= 1 | plugin == null) return;
+        if (changePageTask != null) changePageTask.cancel();
+
+        // Count every 1 seconds, if reaches a fixed interval, recursive call a new task.
+        changePageTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (interval == 0) return;
+                if (changeState >= changeDelay) {
+                    if (automaticallySkipPage) {
+                        nextPage(player, hologram);
+                        startChangePageTask(player, hologram);
+                    }
+                    else changePageTask.cancel();
+                } else {
+                    onTick(player, hologram);
+                    changeState++;
+                }
+
+            }
+        }.runTaskTimer(plugin, 0, changeDelay);
+    }
+
+    /**
+     * If provided plugin reference, override this method to set interval value in milliseconds.
+     * @return Plugin's check interval for when turning to next page automatically.
+     */
+    public long getInterval() { return 15 * 20L; }
+
+    /**
+     * If provided plugin reference, override this method to create any animation to hologram each tick of one second.
+     * This is defaulted to footer color changing animation as a tick increased.
+     * @param player Focused player.
+     * @param hologram Focused hologram.
+     */
+    public void onTick(Player player, Hologram hologram) {
+        int footerLength = contentSeparator.length();
+        int highlightCount = (int) (((float) changeState / changeDelay) * footerLength);
+
+        StringBuilder highlighted = new StringBuilder();
+        for (int i = 0; i < highlightCount; i++) {
+            highlighted.append("-");
+        }
+
+        StringBuilder notH = new StringBuilder();
+        for (int i = 0; i < footerLength - highlightCount; i++) {
+            notH.append("-");
+        }
+
+        replaceLine(hologram.getPage(player),
+                hologram.getPage(player).size() - 1,
+                "§e" + highlighted + "§7" + notH);
+    }
+
+    /**
+     * Turn a new page to player.<br/>
+     * Note that currently there's no previous page function,
+     * calling this beyond page size will loop back to the first page.
+     * @see Hologram#show(Player, int)
+     * @param player Focused player.
+     * @param hologram Focused hologram.
+     */
+    public void nextPage(Player player, Hologram hologram) {
+        try {
+            int nextViewPage = currentPage + 1;
+            if(nextViewPage == pageCount) nextViewPage = 0;
+            hologram.show(player, nextViewPage);
+            currentPage = nextViewPage;
+        }
+        catch (IndexOutOfBoundsException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "[DHAPI] Hologram page indexing out of bounds", ex);
+        }
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/system/Builder.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/Builder.java
@@ -24,14 +24,14 @@
 
 package com.alpsbte.plotsystem.core.system;
 
-import com.alpsbte.alpslib.hologram.HolographicDisplay;
 import com.alpsbte.alpslib.utils.item.ItemBuilder;
 import com.alpsbte.alpslib.utils.item.LegacyLoreBuilder;
 import com.alpsbte.plotsystem.PlotSystem;
 import com.alpsbte.plotsystem.core.database.DatabaseConnection;
-import com.alpsbte.plotsystem.core.holograms.LeaderboardManager;
+import com.alpsbte.plotsystem.core.holograms.HologramRegister;
 import com.alpsbte.plotsystem.core.holograms.PlotsLeaderboard;
 import com.alpsbte.plotsystem.core.holograms.ScoreLeaderboard;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
 import com.alpsbte.plotsystem.core.system.plot.Plot;
 import com.alpsbte.plotsystem.core.system.plot.utils.PlotType;
 import com.alpsbte.plotsystem.utils.enums.Slot;
@@ -187,8 +187,8 @@ public class Builder {
                 .setValue(getScore() + score).setValue(getUUID().toString())
                 .executeUpdate();
 
-        Bukkit.getScheduler().runTask(PlotSystem.getPlugin(), () -> LeaderboardManager.getLeaderboards().stream()
-                .filter(leaderboard -> leaderboard instanceof ScoreLeaderboard).findFirst().ifPresent(HolographicDisplay::reloadAll));
+        Bukkit.getScheduler().runTask(PlotSystem.getPlugin(), () -> HologramRegister.getActiveDisplays().stream()
+                .filter(leaderboard -> leaderboard instanceof ScoreLeaderboard).findFirst().ifPresent(DecentHologramDisplay::reloadAll));
     }
 
     public void addCompletedBuild(int amount) throws SQLException {
@@ -196,8 +196,8 @@ public class Builder {
                 .setValue(getCompletedBuilds() + amount).setValue(getUUID().toString())
                 .executeUpdate();
 
-        Bukkit.getScheduler().runTask(PlotSystem.getPlugin(), () -> LeaderboardManager.getLeaderboards().stream()
-                .filter(leaderboard -> leaderboard instanceof PlotsLeaderboard).findFirst().ifPresent(HolographicDisplay::reloadAll));
+        Bukkit.getScheduler().runTask(PlotSystem.getPlugin(), () -> HologramRegister.getActiveDisplays().stream()
+                .filter(leaderboard -> leaderboard instanceof PlotsLeaderboard).findFirst().ifPresent(DecentHologramDisplay::reloadAll));
     }
 
     public void setPlot(int plotID, Slot slot) throws SQLException {

--- a/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/AbstractTutorial.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/AbstractTutorial.java
@@ -24,8 +24,9 @@
 
 package com.alpsbte.plotsystem.core.system.tutorial;
 
-import com.alpsbte.alpslib.hologram.HolographicDisplay;
-import com.alpsbte.alpslib.npc.AbstractNpc;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
+import com.alpsbte.plotsystem.core.system.tutorial.connector.AbstractNpc;
+// import com.alpsbte.alpslib.npc.AbstractNpc;
 import com.alpsbte.plotsystem.PlotSystem;
 import com.alpsbte.plotsystem.core.system.tutorial.stage.AbstractStage;
 import com.alpsbte.plotsystem.core.system.tutorial.stage.StageTimeline;
@@ -169,7 +170,7 @@ public abstract class AbstractTutorial implements Tutorial {
 
     @Override
     public List<AbstractTutorialHologram> getActiveHolograms() {
-        return HolographicDisplay.activeDisplays.stream()
+        return DecentHologramDisplay.activeDisplays.stream()
                 .filter(AbstractTutorialHologram.class::isInstance)
                 .filter(holo -> holo.isVisible(playerUUID))
                 .map(h -> (AbstractTutorialHologram) h)
@@ -241,7 +242,8 @@ public abstract class AbstractTutorial implements Tutorial {
         TutorialWorld world = worlds.get(tutorialWorldIndex);
         player.teleport(world.getPlayerSpawnLocation());
         npc.create(world.getNpcSpawnLocation(), false, true);
-        Bukkit.getScheduler().runTaskAsynchronously(PlotSystem.getPlugin(), () -> npc.show(player));
+        npc.show(player);
+        npc.getHologram().delete();
     }
 
     @Override

--- a/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/AbstractTutorialHologram.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/AbstractTutorialHologram.java
@@ -24,18 +24,20 @@
 
 package com.alpsbte.plotsystem.core.system.tutorial;
 
-import com.alpsbte.alpslib.hologram.HolographicDisplay;
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
 import com.alpsbte.alpslib.utils.AlpsUtils;
-import me.filoghost.holographicdisplays.api.Position;
-import me.filoghost.holographicdisplays.api.hologram.Hologram;
-import me.filoghost.holographicdisplays.api.hologram.line.TextHologramLine;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import eu.decentsoftware.holograms.api.holograms.HologramLine;
+import eu.decentsoftware.holograms.event.HologramClickEvent;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Vector;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
-public abstract class AbstractTutorialHologram extends HolographicDisplay {
+public abstract class AbstractTutorialHologram extends DecentHologramDisplay {
     protected static final String READ_EMOJI = "✅";
 
     /**
@@ -43,11 +45,12 @@ public abstract class AbstractTutorialHologram extends HolographicDisplay {
      */
     @FunctionalInterface
     public interface ClickAction {
-        void onClick();
+        void onClick(@NotNull HologramClickEvent clickEvent);
     }
 
     private final static int MAX_HOLOGRAM_LENGTH = 48; // The maximum length of a line in the hologram
     private final static String HOLOGRAM_LINE_BREAKER = "%newline%";
+    private final static String EMPTY_TAG = "&f";
 
     protected final Player player;
     protected final int holoId;
@@ -101,7 +104,7 @@ public abstract class AbstractTutorialHologram extends HolographicDisplay {
 
     @Override
     public void create(Player player) {
-        setPosition(Position.of(player.getWorld(), vectorPos.getX(), vectorPos.getY(), vectorPos.getZ()));
+        setLocation(new Location(player.getWorld(), vectorPos.getX(), vectorPos.getY(), vectorPos.getZ()));
         super.create(player);
     }
 
@@ -154,17 +157,14 @@ public abstract class AbstractTutorialHologram extends HolographicDisplay {
         super.reload(playerUUID);
 
         // Set click listener
-        Hologram holo = getHologram(playerUUID);
-        if (holo == null) return;
-        if (readMoreId != -1) {
-            TextHologramLine line = (TextHologramLine) holo.getLines().get(holo.getLines().size() - (markAsReadClickAction == null ? 1 : 3));
-            line.setClickListener((clickEvent) -> handleReadMoreClickAction());
-        }
+        Hologram holo = this.getHologram(playerUUID);
+
+        if (readMoreId != -1)  super.setClickListener((clickEvent) -> handleReadMoreClickAction());
         if (markAsReadClickAction != null) {
-            TextHologramLine line = (TextHologramLine) holo.getLines().get(holo.getLines().size() - 1);
-            line.setClickListener((clickEvent) -> {
+            HologramLine line = holo.getPage(0).getLines().get(holo.getPage(0).getLines().size() - 1);
+            super.setClickListener((clickEvent) -> {
                 line.setText(getMarkAsReadActionDoneText());
-                markAsReadClickAction.onClick();
+                markAsReadClickAction.onClick(clickEvent);
             });
         }
     }

--- a/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/Tutorial.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/Tutorial.java
@@ -24,7 +24,8 @@
 
 package com.alpsbte.plotsystem.core.system.tutorial;
 
-import com.alpsbte.alpslib.npc.AbstractNpc;
+// import com.alpsbte.alpslib.npc.AbstractNpc;
+import com.alpsbte.plotsystem.core.system.tutorial.connector.AbstractNpc;
 import com.alpsbte.plotsystem.core.system.tutorial.stage.StageTimeline;
 import com.alpsbte.plotsystem.core.system.tutorial.stage.tasks.AbstractTask;
 import org.bukkit.World;

--- a/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/connector/AbstractNpc.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/connector/AbstractNpc.java
@@ -1,0 +1,223 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright © 2023, ASEAN Build The Earth <bteasean@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package com.alpsbte.plotsystem.core.system.tutorial.connector;
+
+// import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.FancyNpcsPlugin;
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.NpcData;
+import de.oliver.fancynpcs.api.utils.SkinFetcher;
+import de.oliver.fancynpcs.api.utils.SkinFetcher.SkinData;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.UUID;
+import java.util.Objects;
+
+/**
+ * FancyNpcs Wrapper class to manage NPC visibility and name-tag holograms.
+ * Using SkinFetcher to get minecraft skin from signature or player UUID.
+ * @see SkinFetcher
+ */
+public abstract class AbstractNpc {
+    /**
+     * All active NPC constructed by the abstract class.
+     */
+    public static final List<AbstractNpc> activeNPCs = new ArrayList<>();
+    private static final String EMPTY_TAG = "<empty>";
+    private static final String IDENTIFIER_TAG = "alpslib_";
+
+    /**
+     * Get the NPC name.
+     * @param playerUUID Focused player.
+     * @return The NPC name to be overridden.
+     */
+    public abstract String getDisplayName(UUID playerUUID);
+
+    /**
+     * Get the NPC Name suffix message to be added.
+     * @param playerUUID Focused player.
+     * @return The NPC name suffix to be overridden.
+     */
+    public abstract String getActionTitle(UUID playerUUID);
+
+    private final String id;
+    private final SkinData skin;
+    private Npc npc;
+    private NpcHologram hologram;
+
+    /**
+     * Create a new NPC by custom skin texture and signature.
+     * @see <a href="https://mineskin.org/">mineskin.org</a>
+     * Minecraft skin texture and signature can be generated at Mineskin.
+     * @param id Identifier for this NPC to prevent duplicate naming.
+     * @param skinTexture Minecraft skin texture value.
+     * @param skinSignature Minecraft skin texture signature.
+     */
+    public AbstractNpc(String id, String skinTexture, String skinSignature) {
+        this.id = id;
+        this.skin = new SkinData(IDENTIFIER_TAG + id, skinTexture, skinSignature);
+    }
+
+    /**
+     * Create NPC Data on a world with location, the npc will not be visible to any player yet.
+     * @param spawnPos The NPC spawn location.
+     * @param saveToFile Whether the NPC Data will be persistent.
+     * @param turnToPlayer Will the NPC always facing the player.
+     */
+    public void create(Location spawnPos, boolean saveToFile, boolean turnToPlayer) {
+        if (npc != null) delete();
+
+        NpcData npcData = new NpcData(id, UUID.randomUUID(), spawnPos);
+        npc = FancyNpcsPlugin.get().getNpcAdapter().apply(npcData);
+        npc.getData().setSkin(skin);
+        npc.getData().setDisplayName(EMPTY_TAG);
+        npc.getData().setTurnToPlayer(turnToPlayer);
+        npc.setSaveToFile(saveToFile);
+        // TODO: uncomment this after we have our npc visibility package
+        // npc.getData().setOnlyVisibleTo(true);
+        npc.create();
+        FancyNpcsPlugin.get().getNpcManager().registerNpc(npc);
+        hologram = new NpcHologram(IDENTIFIER_TAG + id, spawnPos, this);
+        activeNPCs.add(this);
+    }
+
+    /**
+     * Spawn the NPC on a location, this will only be visible to a focused player.
+     * @see Npc#spawn(Player) FancyNpcs spawn method.
+     * @param player Focused player.
+     */
+    public void show(Player player) {
+        if (npc == null) return;
+        Bukkit.getScheduler().runTaskAsynchronously(FancyNpcsPlugin.get().getPlugin(), () -> {
+            // TODO: uncomment this after we have our npc visibility package
+            //npc.getData().showToPlayer(player.getUniqueId());
+            npc.spawn(player);
+            if (hologram != null && player.getWorld().getName().equals(Objects.requireNonNull(hologram.getLocation().getWorld()).getName()))
+                hologram.create(player);
+        });
+    }
+
+    /**
+     * Spawn the NPC on a location, with any player be able to see.
+     * @see Npc#spawnForAll() FancyNpcs::Npc#spawnForAll()
+     */
+    public void showForAll() {
+        if (npc == null) return;
+        // TODO: uncomment this after we have our npc visibility package
+        //npc.getData().setOnlyVisibleTo(false);
+        npc.spawnForAll();
+        if (hologram != null) {
+            Bukkit.getOnlinePlayers().forEach(player -> {
+                if (player.getWorld().getName().equals(Objects.requireNonNull(hologram.getLocation().getWorld()).getName()))
+                    Bukkit.getScheduler().runTask(FancyNpcsPlugin.get().getPlugin(), () -> hologram.create(player));
+            });
+        }
+    }
+
+    /**
+     * Hide NPC from the focused player.
+     * @param player Focused player.
+     */
+    public void hide(Player player) {
+        if (npc == null || !npc.getIsVisibleForPlayer().containsKey(player.getUniqueId())) return;
+        hologram.remove(player.getUniqueId());
+        // TODO: uncomment this after we have our npc visibility package
+        // npc.getData().hideFromPlayer(player.getUniqueId());
+        npc.remove(player);
+    }
+
+    /**
+     * Update NPC name-tag hologram and NPC glow.
+     * @param playerUUID The focused player.
+     * @param isVisible Is the name-tag visible.
+     * @param enableGlow Set npc to glow
+     * @see NpcData#setGlowing(boolean)
+     */
+    public void setActionTitleVisibility(UUID playerUUID, boolean isVisible, boolean enableGlow) {
+        if (hologram != null && hologram.getHologram(playerUUID) != null && !hologram.getHologram(playerUUID).isDisabled())
+            hologram.setActionTitleVisibility(playerUUID, isVisible);
+        if (npc != null) {
+            if (npc.getData().isGlowing() != enableGlow) {
+                npc.getData().setGlowing(enableGlow);
+                npc.updateForAll();
+            }
+        }
+    }
+
+    /**
+     * Delete this NPC.
+     */
+    public void delete() {
+        if (npc != null) npc.removeForAll();
+        FancyNpcsPlugin.get().getNpcManager().removeNpc(npc);
+        if (hologram != null) hologram.delete();
+        activeNPCs.remove(this);
+    }
+
+    /**
+     * Get the identifier used to construct this NPC.
+     * @return Identifier
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Get this NPC skin texture value.
+     * @return Minecraft Skin Value
+     */
+    public String getSkinTexture() {
+        return skin.value();
+    }
+
+    /**
+     * Get this NPC skin signature value.
+     * @return Minecraft Skin Signature
+     */
+    public String getSkinSignature() {
+        return skin.signature();
+    }
+
+    /**
+     * Get the FancyNpcs class created by this wrapper.
+     * @return npc
+     */
+    public Npc getNpc() {
+        return npc;
+    }
+
+    /**
+     * Get the NPC name-tag hologram.
+     * @return NpcHologram
+     */
+    public NpcHologram getHologram() {
+        return hologram;
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/connector/NpcHologram.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/connector/NpcHologram.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License (MIT)
+ *
+ *  Copyright © 2023, ASEAN Build The Earth <bteasean@gmail.com>
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+
+package com.alpsbte.plotsystem.core.system.tutorial.connector;
+
+import com.alpsbte.plotsystem.core.holograms.connector.DecentHologramDisplay;
+// import de.oliver.fancynpcs.FancyNpcs;
+import de.oliver.fancynpcs.api.FancyNpcsPlugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.UUID;
+import java.util.Map;
+import java.util.List;
+import java.util.Collections;
+import java.util.ArrayList;
+
+/**
+ * NPC name-tag hologram to show above npc head.
+ */
+public class NpcHologram extends DecentHologramDisplay {
+    private static final double NPC_HOLOGRAM_Y = 2.3;
+    private static final double NPC_HOLOGRAM_Y_WITH_ACTION_TITLE = 2.6;
+
+    private final AbstractNpc npc;
+    private final Map<UUID, Boolean> isActionTitleVisible = new HashMap<>();
+
+    private Location baseLocation;
+
+    /**
+     * Create a new NPC name-tag Hologram.
+     * @param id Any identifier to be set as hologram name.
+     * @param location The location to create this hologram.
+     * @param npc AbstractNpc to be assigned to this hologram.
+     */
+    public NpcHologram(@NotNull String id, Location location, AbstractNpc npc) {
+        super(id, location.clone().add(0, NPC_HOLOGRAM_Y, 0), true);
+        this.npc = npc;
+        this.baseLocation = location;
+    }
+
+    /**
+     * Create NPC name-tag, with view permission set to its assigned NPC's viewing player.
+     * @param player The player that will be able to view this hologram
+     */
+    @Override
+    public void create(Player player) {
+        Bukkit.getScheduler().runTask(FancyNpcsPlugin.get().getPlugin(), () -> {
+            if(npc.getNpc().getIsVisibleForPlayer().containsKey(player.getUniqueId())
+                    && npc.getNpc().getIsVisibleForPlayer().get(player.getUniqueId())) {
+                super.create(player);
+            }
+        });
+    }
+
+    /**
+     * This always returns true since view permission check
+     * of this hologram happens before creating the hologram.
+     * @param playerUUID Focused player
+     * @return TRUE
+     */
+    @Override
+    public boolean hasViewPermission(UUID playerUUID) { return true; }
+
+    @Override
+    public ItemStack getItem() {
+        return null;
+    }
+
+    @Override
+    public String getTitle(UUID playerUUID) {
+        return npc.getDisplayName(playerUUID);
+    }
+
+    @Override
+    public List<DataLine<?>> getHeader(UUID playerUUID) {
+        return Collections.singletonList(new TextLine(this.getTitle(playerUUID)));
+    }
+
+    @Override
+    public List<DataLine<?>> getContent(UUID playerUUID) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<DataLine<?>> getFooter(UUID playerUUID) {
+        return isActionTitleVisible(playerUUID) ? Collections.singletonList(new TextLine(npc.getActionTitle(playerUUID))) : new ArrayList<>();
+    }
+
+    @Override
+    public void setLocation(Location newLocation) {
+        this.baseLocation = newLocation;
+        for (UUID playerUUID : getHolograms().keySet())
+            getHolograms().get(playerUUID)
+            .setLocation(newLocation.add(0, isActionTitleVisible(playerUUID) ?
+                NPC_HOLOGRAM_Y_WITH_ACTION_TITLE : NPC_HOLOGRAM_Y, 0));
+    }
+
+    /**
+     * Update this name-tag hologram's location and visibility.
+     * @param playerUUID Focused player.
+     * @param isVisible Set the hologram visible or not.
+     */
+    public void setActionTitleVisibility(UUID playerUUID, boolean isVisible) {
+        isActionTitleVisible.put(playerUUID, isVisible);
+        getHologram(playerUUID).setLocation(baseLocation.clone().add(0, isActionTitleVisible(playerUUID) ?
+            NPC_HOLOGRAM_Y_WITH_ACTION_TITLE : NPC_HOLOGRAM_Y, 0));
+        reload(playerUUID);
+    }
+
+    /**
+     * Get whether this hologram is visible.
+     * @param playerUUID Focused player.
+     * @return isActionTitleVisible
+     */
+    public boolean isActionTitleVisible(UUID playerUUID) {
+        return isActionTitleVisible.getOrDefault(playerUUID, false);
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/stage/TutorialNPC.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/stage/TutorialNPC.java
@@ -24,7 +24,8 @@
 
 package com.alpsbte.plotsystem.core.system.tutorial.stage;
 
-import com.alpsbte.alpslib.npc.AbstractNpc;
+import com.alpsbte.plotsystem.core.system.tutorial.connector.AbstractNpc;
+// import com.alpsbte.alpslib.npc.AbstractNpc;
 import com.alpsbte.plotsystem.PlotSystem;
 import com.alpsbte.plotsystem.utils.io.ConfigPaths;
 import com.alpsbte.plotsystem.utils.io.LangPaths;

--- a/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/stage/tasks/message/CreateHologramTask.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/tutorial/stage/tasks/message/CreateHologramTask.java
@@ -27,8 +27,10 @@ package com.alpsbte.plotsystem.core.system.tutorial.stage.tasks.message;
 import com.alpsbte.plotsystem.core.system.tutorial.AbstractTutorialHologram;
 import com.alpsbte.plotsystem.core.system.tutorial.TutorialUtils;
 import com.alpsbte.plotsystem.core.system.tutorial.stage.tasks.AbstractTask;
+import eu.decentsoftware.holograms.event.HologramClickEvent;
 import net.kyori.adventure.text.Component;
 import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
@@ -51,7 +53,7 @@ public class CreateHologramTask extends AbstractTask {
     @Override
     public void performTask() {
         for (AbstractTutorialHologram hologram : hologramsToCreate) {
-            if (isMarkAsRead) hologram.setMarkAsReadClickAction(() -> onMarkAsReadClick(hologram.getId()));
+            if (isMarkAsRead) hologram.setMarkAsReadClickAction((@NotNull HologramClickEvent clickEvent) -> onMarkAsReadClick(hologram.getId()));
             hologram.create(player);
         }
         if (!isMarkAsRead) setTaskDone();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ api-version: "1.20"
 name: Plot-System
 author: R3tuxn & Cinnazeyy
 softdepend: [LangLibs, FancyNpcs, VoidGen, FastAsyncWorldEdit, Multiverse-Core, WorldEdit,
-             HolographicDisplays, WorldGuard, WorldGuardExtraFlags, HeadDatabase, ProtocolLib, ParticleNativeAPI]
+             DecentHolograms, WorldGuard, WorldGuardExtraFlags, HeadDatabase, ProtocolLib, ParticleNativeAPI]
 
 commands:
   cancelchat:


### PR DESCRIPTION
## Fixes for 2 major package for minecraft 1.21.1 support
* HolographicDisplay :arrow_right:  DecentHolograms (due to deprecation)
* Upstream FancyNpcs to 2.3.0 (1.21.1 support)

## Summary
* created 2 connector point for this feature (`com.alpsbte.plotsystem.core.holograms.connector` & `com.alpsbte.plotsystem.core.system.tutorial.connector`)
* the connector packages can be move to the alps-lib repo to be use independently
* the holograms functionality is almost complete. I'm not sure is the paging would work correctly
```diff
+ HologramRegister.java          (new for registering hologram)
- LeaderboardConfiguration.java  (renamed)
+ HologramConfiguration.java
- LeaderboardManager.java        (renamed)
+ HologramManager.java
```

## More Info
* :information_source: I tested hologram and NPC only in the tutorial system but it should works correctly.
* :information_source: Note that hologram click functionality seems to be changed, The click hitbox is now the entire hologram not by each line anymore.
* :warning:  The paging for leaderboard hologram may be broken (I'm lazy to get enough junk data to my db for testing it)
* :warning:  NPC visibility is commented out because I need the npc repo to be updated for that