### PR TITLE
[Fix] Support for plot height below MIN_WORLD_HEIGHT

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/CityPlotWorld.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/CityPlotWorld.java
@@ -96,22 +96,33 @@ public class CityPlotWorld extends PlotWorld {
     /**
      * Calculate additional height for the plot
      *
-     * @return additional height
+     * @return The origin plot height from schematic if it is in plot world boundary, else 0
      * @throws IOException if the outline schematic fails to load
      */
     @Beta
     public int getWorldHeight() throws IOException {
-        Clipboard clipboard = FaweAPI.load(getPlot().getOutlinesSchematic());
-        int plotHeight = clipboard != null ? clipboard.getMinimumPoint().y() : MIN_WORLD_HEIGHT;
+        try (Clipboard clipboard = Objects.requireNonNull(ClipboardFormats.findByFile(getPlot().getOutlinesSchematic())).load(getPlot().getOutlinesSchematic())) {
 
-        // Plots created below min world height are not supported
-        if (plotHeight < MIN_WORLD_HEIGHT) throw new IOException("Plot height is not supported");
+            if (clipboard != null) {
+                int plotHeight = clipboard.getMinimumPoint().y();
 
-        // Move Y height to a usable value below 256 blocks
-        while (plotHeight >= 150) {
-            plotHeight -= 150;
+                /// Minimum building height for a plot (this should be configurable depending on minecraft build limit)
+                /// This is in the case that a plot is created at y level 300 where the max build limit is 318,
+                /// so you don't want builder to only be able to build for 18 blocks
+                int minBuildingHeight = 128;
+
+                /// Negative y level of the current minecraft version (1.21)
+                /// Additional ground layer the plot use to save as schematic need to be included for plot's y-level
+                int groundLayer = 64;
+
+                // Plots created outside of vanilla build limit or the build-able height is too small
+                if (plotHeight + groundLayer < MIN_WORLD_HEIGHT + groundLayer
+                        | plotHeight + groundLayer + minBuildingHeight > MAX_WORLD_HEIGHT + groundLayer)
+                    return 0; // throw new IOException("Plot height is out of range.");
+                return plotHeight;
+            }
         }
-        return plotHeight;
+        throw new IOException("A Plot's Outline schematic fails to load, cannot get clipboard.");
     }
 
     /**


### PR DESCRIPTION
## Support for all Terra server y level

https://github.com/AlpsBTE/Plot-System/blob/a994eb7a29b24b1501ee7a199d0c92257ad2948c/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/CityPlotWorld.java#L107

* Fix fatal exception for plots below `MIN_WORLD_HEIGHT` by clamping height to 0

* Previously, any plot saved with a Y level below `MIN_WORLD_HEIGHT` caused a fatal exception, making it impossible to generate. This is fixed by snapping out-of-bound plots to `MIN_WORLD_HEIGHT`, therefore `getWorldHeight()` returns 0 in such cases. 

* Alternatively, `getWorldHeight()` could directly return 0 to prevent the issue.

---

dev notes:
- This is a very simple fix perhaps this pr wont even need to get merge, just decide it when you guys want to fix this bug.
- I just finished setting up asean bte plot server for 1.21 and this issue has always been here, better if this get fix to main repo some day.
- I tested the plot pasting mechanism and this fix would get handled by PlotUtil code very well i dont see any concerning bug at all.
- :warning: one bug i saw is an edge case where a plot is saved at the lowest build limit, then plot schematic and environment schematic doesnt get paste of the same level.
- this also fixes opening issue here: #123  #109