### PR TITLE
Fix Plot-System eating up your storage like cookies

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/AbstractPlot.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/AbstractPlot.java
@@ -11,13 +11,14 @@ import com.alpsbte.plotsystem.utils.Utils;
 import com.alpsbte.plotsystem.utils.conversion.CoordinateConversion;
 import com.alpsbte.plotsystem.utils.conversion.projection.OutOfProjectionBoundsException;
 import com.alpsbte.plotsystem.utils.enums.Status;
-import com.sk89q.worldedit.extent.clipboard.Clipboard;
+import com.fastasyncworldedit.core.extent.clipboard.CPUOptimizedClipboard;
 import com.sk89q.worldedit.extent.clipboard.io.BuiltInClipboardFormat;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardFormat;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
 import com.sk89q.worldedit.math.BlockVector2;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -140,7 +141,9 @@ public abstract class AbstractPlot {
     public BlockVector3 getCoordinates() throws IOException {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(getInitialSchematicBytes());
         try (ClipboardReader reader = CLIPBOARD_FORMAT.getReader(inputStream)) {
-            Clipboard clipboard = reader.read();
+            var clipboard = reader.read(null, dimensions -> new CPUOptimizedClipboard(
+                    new CuboidRegion(null, BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE))
+            ));
             if (clipboard != null) return clipboard.getOrigin();
         }
         return null;
@@ -149,7 +152,9 @@ public abstract class AbstractPlot {
     public BlockVector3 getCenter() {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(getInitialSchematicBytes());
         try (ClipboardReader reader = CLIPBOARD_FORMAT.getReader(inputStream)){
-            Clipboard clipboard = reader.read();
+            var clipboard = reader.read(null, dimensions -> new CPUOptimizedClipboard(
+                    new CuboidRegion(null, BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE))
+            ));
             if (clipboard != null) {
                 Vector3 clipboardCenter = clipboard.getRegion().getCenter();
                 return BlockVector3.at(clipboardCenter.x(), this.getWorld().getPlotHeightCentered(), clipboardCenter.z());

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/utils/PlotUtils.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/utils/PlotUtils.java
@@ -20,13 +20,13 @@ import com.alpsbte.plotsystem.utils.enums.Status;
 import com.alpsbte.plotsystem.utils.io.ConfigPaths;
 import com.alpsbte.plotsystem.utils.io.LangPaths;
 import com.alpsbte.plotsystem.utils.io.LangUtil;
+import com.fastasyncworldedit.core.extent.clipboard.CPUOptimizedClipboard;
 import com.github.fierioziy.particlenativeapi.api.ParticleNativeAPI;
 import com.github.fierioziy.particlenativeapi.api.Particles_1_13;
 import com.github.fierioziy.particlenativeapi.plugin.ParticleNativePlugin;
 import com.sk89q.worldedit.WorldEditException;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
-import com.sk89q.worldedit.extent.clipboard.BlockArrayClipboard;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardWriter;
@@ -182,7 +182,9 @@ public final class PlotUtils {
     public static @Nullable CuboidRegion getPlotAsRegion(@NotNull AbstractPlot plot) throws IOException {
         Clipboard clipboard;
         try (ClipboardReader reader = AbstractPlot.CLIPBOARD_FORMAT.getReader(new ByteArrayInputStream(plot.getInitialSchematicBytes()))) {
-            clipboard = reader.read();
+            clipboard = reader.read(null, dimensions -> new CPUOptimizedClipboard(
+                    new CuboidRegion(null, BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE))
+            ));
         }
         if (clipboard == null) return null;
 
@@ -202,7 +204,9 @@ public final class PlotUtils {
         Clipboard clipboard;
         ByteArrayInputStream inputStream = new ByteArrayInputStream(plot.getInitialSchematicBytes());
         try (ClipboardReader reader = AbstractPlot.CLIPBOARD_FORMAT.getReader(inputStream)) {
-            clipboard = reader.read();
+            clipboard = reader.read(null, dimensions -> new CPUOptimizedClipboard(
+                    new CuboidRegion(null, BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE))
+            ));
         }
 
         Polygonal2DRegion region = new Polygonal2DRegion(
@@ -212,7 +216,7 @@ public final class PlotUtils {
                 clipboard.getMaximumPoint().y()
         );
 
-        BlockArrayClipboard newClipboard = new BlockArrayClipboard(region);
+        Clipboard newClipboard = new CPUOptimizedClipboard(region);
         newClipboard.setOrigin(BlockVector3.at(region.getCenter().x(), region.getMinimumPoint().y(), region.getCenter().z()));
         ForwardExtentCopy copy = new ForwardExtentCopy(
                 clipboard,
@@ -262,7 +266,7 @@ public final class PlotUtils {
 
         // Copy and write finished plot clipboard to schematic
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try (Clipboard cb = new BlockArrayClipboard(region)) {
+        try (Clipboard cb = new CPUOptimizedClipboard(region)) {
             cb.setOrigin(BlockVector3.at(plotCenter.x(), cuboidRegion.getMinimumY(), (double) plotCenter.z()));
 
             ForwardExtentCopy forwardExtentCopy = new ForwardExtentCopy(Objects.requireNonNull(region.getWorld()), region, cb, region.getMinimumPoint());
@@ -293,7 +297,9 @@ public final class PlotUtils {
         Clipboard clipboard;
         ByteArrayInputStream inputStream = new ByteArrayInputStream(plot.getInitialSchematicBytes());
         try (ClipboardReader reader = AbstractPlot.CLIPBOARD_FORMAT.getReader(inputStream)) {
-            clipboard = reader.read();
+            clipboard = reader.read(null, dimensions -> new CPUOptimizedClipboard(
+                    new CuboidRegion(null, BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE))
+            ));
         }
         if (clipboard == null) return null;
 

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/CityPlotWorld.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/CityPlotWorld.java
@@ -6,9 +6,12 @@ import com.alpsbte.plotsystem.core.system.plot.utils.PlotUtils;
 import com.alpsbte.plotsystem.utils.Utils;
 import com.alpsbte.plotsystem.utils.io.LangPaths;
 import com.alpsbte.plotsystem.utils.io.LangUtil;
+import com.fastasyncworldedit.core.extent.clipboard.CPUOptimizedClipboard;
 import com.google.common.annotations.Beta;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -74,7 +77,9 @@ public class CityPlotWorld extends PlotWorld {
         Clipboard clipboard;
         ByteArrayInputStream inputStream = new ByteArrayInputStream(getPlot().getInitialSchematicBytes());
         try (ClipboardReader reader = AbstractPlot.CLIPBOARD_FORMAT.getReader(inputStream)) {
-            clipboard = reader.read();
+            clipboard = reader.read(null, dimensions -> new CPUOptimizedClipboard(
+                    new CuboidRegion(null, BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE))
+            ));
         }
         if (clipboard != null) {
             int plotHeight = clipboard.getMinimumPoint().y();

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/PlotWorld.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/world/PlotWorld.java
@@ -8,10 +8,12 @@ import com.alpsbte.plotsystem.core.system.plot.TutorialPlot;
 import com.alpsbte.plotsystem.core.system.plot.generator.AbstractPlotGenerator;
 import com.alpsbte.plotsystem.utils.DependencyManager;
 import com.alpsbte.plotsystem.utils.Utils;
+import com.fastasyncworldedit.core.extent.clipboard.CPUOptimizedClipboard;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
 import com.sk89q.worldedit.extent.clipboard.io.ClipboardReader;
 import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
@@ -142,7 +144,9 @@ public class PlotWorld implements IWorld {
             Clipboard clipboard;
             ByteArrayInputStream inputStream = new ByteArrayInputStream(plot.getInitialSchematicBytes());
             try (ClipboardReader reader = AbstractPlot.CLIPBOARD_FORMAT.getReader(inputStream)) {
-                clipboard = reader.read();
+                clipboard = reader.read(null, dimensions -> new CPUOptimizedClipboard(
+                        new CuboidRegion(null, BlockVector3.ZERO, dimensions.subtract(BlockVector3.ONE))
+                ));
             }
             if (clipboard != null) {
                 return (int) clipboard.getRegion().getCenter().y() - clipboard.getMinimumPoint().y();


### PR DESCRIPTION
Replace Clipboard with CPUOptimizedClipboard for peformance improvements

This also fixes that the clipboard is never deleated and grows infinite. There is also MemoryOptimizedClipboard but that has most likely worse performance.