### PR TITLE
Create AbandonConfirmMenu.java and default item for plot-abandon to TNT

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/core/menus/AbandonConfirmMenu.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/menus/AbandonConfirmMenu.java
@@ -1,0 +1,68 @@
+package com.alpsbte.plotsystem.core.menus;
+
+import com.alpsbte.alpslib.utils.item.ItemBuilder;
+import com.alpsbte.alpslib.utils.item.LoreBuilder;
+import com.alpsbte.plotsystem.core.system.plot.Plot;
+import com.alpsbte.plotsystem.utils.Utils;
+import com.alpsbte.plotsystem.utils.io.LangPaths;
+import com.alpsbte.plotsystem.utils.io.LangUtil;
+import com.alpsbte.plotsystem.utils.items.BaseItems;
+import com.alpsbte.plotsystem.utils.items.MenuItems;
+import org.bukkit.entity.Player;
+import org.ipvp.canvas.mask.BinaryMask;
+import org.ipvp.canvas.mask.Mask;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+import static net.kyori.adventure.text.format.TextDecoration.BOLD;
+
+public class AbandonConfirmMenu extends AbstractMenu {
+    private final Plot plot;
+
+    public AbandonConfirmMenu(Player player, Plot plot) {
+        super(3, "Abandon plot #" + plot.getId() + "?", player);
+        this.plot = plot;
+    }
+
+    @Override
+    protected void setMenuItemsAsync() {
+        getMenu().getSlot(12)
+                .setItem(new ItemBuilder(BaseItems.PLOT_ABANDON.getItem())
+                        .setName(text(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuTitle.ABANDON), RED).decoration(BOLD, true))
+                        .setLore(new LoreBuilder()
+                                .addLine(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuDescription.ABANDON), true)
+                                .emptyLine()
+                                .addLine(Utils.ItemUtils.getNoteFormat(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.Note.WONT_BE_ABLE_CONTINUE_BUILDING)))
+                                .build())
+                        .build());
+
+        getMenu().getSlot(14)
+                .setItem(new ItemBuilder(BaseItems.MENU_BACK.getItem())
+                        .setName(text(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuTitle.CANCEL), RED).decoration(BOLD, true))
+                        .build());
+    }
+
+    @Override
+    protected void setItemClickEventsAsync() {
+        getMenu().getSlot(12).setClickHandler((clickPlayer, clickInformation) -> {
+            clickPlayer.closeInventory();
+            clickPlayer.performCommand("plot abandon " + plot.getId());
+        });
+
+        getMenu().getSlot(14).setClickHandler((clickPlayer, clickInformation) -> {
+            clickPlayer.closeInventory();
+            new PlotActionsMenu(clickPlayer, plot);
+        });
+    }
+
+    @Override
+    protected Mask getMask() {
+        return BinaryMask.builder(getMenu())
+                .item(Utils.DEFAULT_ITEM)
+                .pattern(Utils.FULL_MASK)
+                .pattern(Utils.EMPTY_MASK)
+                .pattern(Utils.FULL_MASK)
+                .build();
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/menus/AbandonConfirmMenu.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/menus/AbandonConfirmMenu.java
@@ -7,13 +7,11 @@ import com.alpsbte.plotsystem.utils.Utils;
 import com.alpsbte.plotsystem.utils.io.LangPaths;
 import com.alpsbte.plotsystem.utils.io.LangUtil;
 import com.alpsbte.plotsystem.utils.items.BaseItems;
-import com.alpsbte.plotsystem.utils.items.MenuItems;
 import org.bukkit.entity.Player;
 import org.ipvp.canvas.mask.BinaryMask;
 import org.ipvp.canvas.mask.Mask;
 
 import static net.kyori.adventure.text.Component.text;
-import static net.kyori.adventure.text.format.NamedTextColor.GRAY;
 import static net.kyori.adventure.text.format.NamedTextColor.RED;
 import static net.kyori.adventure.text.format.TextDecoration.BOLD;
 
@@ -21,7 +19,7 @@ public class AbandonConfirmMenu extends AbstractMenu {
     private final Plot plot;
 
     public AbandonConfirmMenu(Player player, Plot plot) {
-        super(3, "Abandon plot #" + plot.getId() + "?", player);
+        super(3, LangUtil.getInstance().get(player, LangPaths.MenuTitle.ABANDON_CONFIRM, String.valueOf(plot.getId())), player);
         this.plot = plot;
     }
 

--- a/src/main/java/com/alpsbte/plotsystem/core/menus/AbandonConfirmMenu.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/menus/AbandonConfirmMenu.java
@@ -1,0 +1,67 @@
+package com.alpsbte.plotsystem.core.menus;
+
+import com.alpsbte.alpslib.utils.item.ItemBuilder;
+import com.alpsbte.alpslib.utils.item.LoreBuilder;
+import com.alpsbte.plotsystem.core.system.plot.Plot;
+import com.alpsbte.plotsystem.utils.Utils;
+import com.alpsbte.plotsystem.utils.io.LangPaths;
+import com.alpsbte.plotsystem.utils.io.LangUtil;
+import com.alpsbte.plotsystem.utils.items.BaseItems;
+import com.alpsbte.plotsystem.utils.items.MenuItems;
+import org.bukkit.entity.Player;
+import org.ipvp.canvas.mask.BinaryMask;
+import org.ipvp.canvas.mask.Mask;
+
+import static net.kyori.adventure.text.Component.text;
+import static net.kyori.adventure.text.format.NamedTextColor.RED;
+import static net.kyori.adventure.text.format.TextDecoration.BOLD;
+
+public class AbandonConfirmMenu extends AbstractMenu {
+    private final Plot plot;
+
+    public AbandonConfirmMenu(Player player, Plot plot) {
+        super(3, LangUtil.getInstance().get(player, LangPaths.MenuTitle.ABANDON_CONFIRM, String.valueOf(plot.getId())), player);
+        this.plot = plot;
+    }
+
+    @Override
+    protected void setMenuItemsAsync() {
+        getMenu().getSlot(12)
+                .setItem(new ItemBuilder(BaseItems.PLOT_ABANDON.getItem())
+                        .setName(text(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuTitle.ABANDON), RED).decoration(BOLD, true))
+                        .setLore(new LoreBuilder()
+                                .addLine(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuDescription.ABANDON), true)
+                                .emptyLine()
+                                .addLine(Utils.ItemUtils.getNoteFormat(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.Note.WONT_BE_ABLE_CONTINUE_BUILDING)))
+                                .build())
+                        .build());
+
+        getMenu().getSlot(14)
+                .setItem(new ItemBuilder(BaseItems.MENU_BACK.getItem())
+                        .setName(text(LangUtil.getInstance().get(getMenuPlayer(), LangPaths.MenuTitle.CANCEL), RED).decoration(BOLD, true))
+                        .build());
+    }
+
+    @Override
+    protected void setItemClickEventsAsync() {
+        getMenu().getSlot(12).setClickHandler((clickPlayer, clickInformation) -> {
+            clickPlayer.closeInventory();
+            clickPlayer.performCommand("plot abandon " + plot.getId());
+        });
+
+        getMenu().getSlot(14).setClickHandler((clickPlayer, clickInformation) -> {
+            clickPlayer.closeInventory();
+            new PlotActionsMenu(clickPlayer, plot);
+        });
+    }
+
+    @Override
+    protected Mask getMask() {
+        return BinaryMask.builder(getMenu())
+                .item(MenuItems.borderItem())
+                .pattern(Utils.FULL_MASK)
+                .pattern(Utils.EMPTY_MASK)
+                .pattern(Utils.FULL_MASK)
+                .build();
+    }
+}

--- a/src/main/java/com/alpsbte/plotsystem/core/menus/PlotActionsMenu.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/menus/PlotActionsMenu.java
@@ -138,8 +138,7 @@ public class PlotActionsMenu extends AbstractMenu {
 
         // Set click event for abandon plot item
         getMenu().getSlot(hasReview ? 14 : 16).setClickHandler((clickPlayer, clickInformation) -> {
-            clickPlayer.closeInventory();
-            clickPlayer.performCommand("plot abandon " + plot.getId());
+            new AbandonConfirmMenu(clickPlayer, plot);
         });
 
         // Set click event for feedback menu button

--- a/src/main/java/com/alpsbte/plotsystem/core/menus/PlotActionsMenu.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/menus/PlotActionsMenu.java
@@ -136,8 +136,7 @@ public class PlotActionsMenu extends AbstractMenu {
 
         // Set click event for abandon plot item
         getMenu().getSlot(hasReview ? 14 : 16).setClickHandler((clickPlayer, clickInformation) -> {
-            clickPlayer.closeInventory();
-            clickPlayer.performCommand("plot abandon " + plot.getId());
+            new AbandonConfirmMenu(clickPlayer, plot);
         });
 
         // Set click event for feedback menu button

--- a/src/main/java/com/alpsbte/plotsystem/utils/io/LangPaths.java
+++ b/src/main/java/com/alpsbte/plotsystem/utils/io/LangPaths.java
@@ -86,6 +86,7 @@ public abstract class LangPaths {
         public static final String SUBMIT = MENU_TITLES + "submit";
         public static final String TELEPORT = MENU_TITLES + "teleport";
         public static final String ABANDON = MENU_TITLES + "abandon";
+        public static final String ABANDON_CONFIRM = MENU_TITLES + "abandon-confirm";
         public static final String UNDO_SUBMIT = MENU_TITLES + "undo-submit";
         public static final String MANAGE_MEMBERS = MENU_TITLES + "manage-members";
         public static final String FEEDBACK = MENU_TITLES + "feedback";

--- a/src/main/resources/items.yml
+++ b/src/main/resources/items.yml
@@ -47,7 +47,7 @@ plot-undo-submit:
   material: FIRE_CHARGE
   modelId: ''
 plot-abandon:
-  material: BARRIER
+  material: TNT
   modelId: ''
 plot-teleport:
   material: COMPASS
@@ -111,9 +111,6 @@ review-point-five:
   modelId: ''
 review-submit:
   material: FIREWORK_ROCKET
-  modelId: ''
-review-cancel:
-  material: RED_CONCRETE
   modelId: ''
 review-info:
   material: head(46488)

--- a/src/main/resources/lang/de_DE.yml
+++ b/src/main/resources/lang/de_DE.yml
@@ -82,6 +82,7 @@ menu-title:
   submit: 'Einreichen'
   teleport: 'Teleportieren'
   abandon: 'Löschen'
+  abandon-confirm: 'Plot #{0} löschen?'
   undo-submit: 'Einreichung Zurückziehen'
   manage-members: 'Mitglieder Verwalten'
   feedback: 'Feedback | Bewertung #{0}'

--- a/src/main/resources/lang/en_GB.yml
+++ b/src/main/resources/lang/en_GB.yml
@@ -82,6 +82,7 @@ menu-title:
   submit: 'Submit'
   teleport: 'Teleport'
   abandon: 'Abandon'
+  abandon-confirm: 'Abandon plot #{0}?'
   undo-submit: 'Undo Submit'
   manage-members: 'Manage Members'
   feedback: 'Feedback | Review #{0}'

--- a/src/main/resources/lang/fr_FR.yml
+++ b/src/main/resources/lang/fr_FR.yml
@@ -82,6 +82,7 @@ menu-title:
   submit: 'Soumettre'
   teleport: 'Téléport'
   abandon: 'Abandonner'
+  abandon-confirm: 'Abandonner le Plot #{0} ?'
   undo-submit: 'Annuler Soumission'
   manage-members: 'Gérer Membres'
   feedback: 'Retour | Review #{0}'


### PR DESCRIPTION
This PR changes the behaviour of clicking on the abandon item in the PlotActionsMenu.
Now the button opens up a new confirmation menu where only after clicking on the abandon item again, will the plot be actually abandoned.
This is to prevent trigger happy users accidentally nuking their progress.
Additionally, this PR also changes the default item for the abandon item to TNT. Previously it was a barrier block.

<img width="557" height="268" alt="abandon" src="https://github.com/user-attachments/assets/dc0987ca-1a30-440a-8300-9fc5373a7a4f" />
