### PR TITLE
Fix Issue #186: Orphan Plots

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/core/system/Builder.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/Builder.java
@@ -81,17 +81,18 @@ public class Builder {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean setSlot(Slot slot, int plotId) {
+        int newPlotId = plotId;
         // check for orphans and assign orphan if available
         if (plotId == -1) {
             List<Plot> orphans = getOrphans();
-            if (!orphans.isEmpty()) plotId = orphans.getFirst().getId();
+            if (!orphans.isEmpty()) newPlotId = orphans.getFirst().getId();
         }
 
-        if (DataProvider.BUILDER.setSlot(this.uuid, plotId, slot)) {
+        if (DataProvider.BUILDER.setSlot(this.uuid, newPlotId, slot)) {
             switch (slot) {
-                case FIRST -> firstSlot = plotId;
-                case SECOND -> secondSlot = plotId;
-                default -> thirdSlot = plotId;
+                case FIRST -> firstSlot = newPlotId;
+                case SECOND -> secondSlot = newPlotId;
+                default -> thirdSlot = newPlotId;
             }
             return true;
         }

--- a/src/main/java/com/alpsbte/plotsystem/core/system/Builder.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/Builder.java
@@ -5,10 +5,12 @@ import com.alpsbte.plotsystem.core.database.DataProvider;
 import com.alpsbte.plotsystem.core.system.plot.Plot;
 import com.alpsbte.plotsystem.core.system.plot.utils.PlotType;
 import com.alpsbte.plotsystem.utils.enums.Slot;
+import com.alpsbte.plotsystem.utils.enums.Status;
 import com.alpsbte.plotsystem.utils.io.ConfigPaths;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
+import java.util.List;
 import java.util.UUID;
 
 public class Builder {
@@ -79,6 +81,12 @@ public class Builder {
 
     @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean setSlot(Slot slot, int plotId) {
+        // check for orphans and assign orphan if available
+        if (plotId == -1) {
+            List<Plot> orphans = getOrphans();
+            if (!orphans.isEmpty()) plotId = orphans.getFirst().getId();
+        }
+
         if (DataProvider.BUILDER.setSlot(this.uuid, plotId, slot)) {
             switch (slot) {
                 case FIRST -> firstSlot = plotId;
@@ -127,6 +135,11 @@ public class Builder {
             return Slot.THIRD;
         }
         return null;
+    }
+
+    private List<Plot> getOrphans() {
+        List<Plot> currentPlots = DataProvider.PLOT.getPlots(this, Status.unfinished, Status.unreviewed);
+        return currentPlots.stream().filter(plot -> getSlotByPlotId(plot.getId()) == null).toList();
     }
 
     public static Builder byUUID(UUID uuid) {

--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/PlotHandler.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/PlotHandler.java
@@ -102,7 +102,7 @@ public class PlotHandler {
         }
 
         // Assign
-        if (!builder.setSlot(builder.getFreeSlot(), plot.getId())) return false;
+        if (!builder.setSlot(freeSlot, plot.getId())) return false;
         if (!plot.setStatus(Status.unfinished)) return false;
         return plot.setPlotOwner(builder);
     }

--- a/src/main/java/com/alpsbte/plotsystem/core/system/review/PlotReview.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/review/PlotReview.java
@@ -75,20 +75,12 @@ public class PlotReview {
     public boolean undoReview() {
         // remove owner score and remove plot from slot
         if (!plot.getPlotOwner().addScore(splitScore == -1 ? -score : -splitScore)) return false;
+        if (!restorePlotSlot(plot.getPlotOwner())) return false;
 
-        Slot slot = plot.getPlotOwner().getSlotByPlotId(plot.getId()); // get slot if plot is still in slots (rejected)
-        if (slot == null) slot = plot.getPlotOwner().getFreeSlot(); // get new slot otherwise (completed)
-        if (slot == null) return false;
-
-        if (!plot.getPlotOwner().setSlot(slot, plot.getId())) return false;
-
-        // remove members score and remove plot from slot
+        // remove member's score and remove plot from slot
         for (Builder member : plot.getPlotMembers()) {
             if (!member.addScore(-splitScore)) return false;
-
-            Slot memberSlot = member.getSlotByPlotId(plot.getId());
-            if (memberSlot == null) memberSlot = member.getFreeSlot();
-            if (memberSlot == null || member.setSlot(memberSlot, plot.getId())) return false;
+            if (!restorePlotSlot(member)) return false;
         }
 
         boolean successful = true;
@@ -108,5 +100,24 @@ public class PlotReview {
         }
 
         return successful;
+    }
+
+    /**
+     * Tries to assign the plot to a slot again if possible.
+     * If all slots are occupied, the plot won't be assigned to a slot, but still accessible via /plots
+     *
+     * @param builder target builder (owner or member)
+     * @return True if the slot was assigned successfully, false otherwise
+     */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private boolean restorePlotSlot(Builder builder) {
+        Slot slot = builder.getSlotByPlotId(plot.getId()); // get slot if plot is still in slots (rejected)
+        if (slot == null) slot = builder.getFreeSlot(); // get new slot otherwise (completed)
+        if (slot == null) {
+            PlotSystem.getPlugin().getComponentLogger().warn("Skipping slot restore for plot #{} and builder {}. All slots are occupied!", plot.getId(), builder.getName());
+            return true;
+        }
+
+        return builder.setSlot(slot, plot.getId());
     }
 }


### PR DESCRIPTION
When using undoreview, it can happen that a builder already filled up all slots again after the review was completed, meaning undoreview cannot set the plot to a slot again, resulting in an orphan plot that is assigned to a builder but not a slot.
This PR changes how the undoreview() method treats this edgecase by simply returning true instead of false.
This will still cause an orphan, but not fail the /undoreview command early and result in the orphans at least being accessible via the player plots menu.

Additionally, this PR also adds a check for whenever a slot is getting freed up, to assign the next orphan instead.