### PR TITLE
ci(release): add release pipeline and switch versioning to git-semver

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,27 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bug'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+      - 'documentation'
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,41 @@
+name: Update Release Draft
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-draft:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Compute next version
+        id: version
+        run: |
+          NEXT="$(./gradlew -q printVersion)"
+          echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - name: Update release draft
+        uses: release-drafter/release-drafter@v6
+        with:
+          version: ${{ steps.version.outputs.next }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Attach Release Artifacts
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew clean build
+
+      - name: Attach shaded JAR to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/libs/*.jar
+          fail_on_unmatched_files: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    alias(libs.plugins.git.version)
+    alias(libs.plugins.git.semver)
     alias(libs.plugins.shadow)
 }
 
@@ -61,11 +61,8 @@ dependencies {
     compileOnly(libs.io.papermc.paper.paper.api)
 }
 
-val versionDetails: groovy.lang.Closure<com.palantir.gradle.gitversion.VersionDetails> by extra
-val details = versionDetails()
-
 group = "com.alpsbte"
-version = "5.0.3" + "-" + details.gitHash + "-SNAPSHOT"
+version = semver.semVersion
 description = "An easy to use building system for the BuildTheEarth project."
 java.sourceCompatibility = JavaVersion.VERSION_21
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ org-mariadb-jdbc-mariadb-java-client = "3.5.7" #  https://central.sonatype.com/a
 com-intellectualsites-bom-bom-newest = "1.55" # Ref: https://github.com/IntellectualSites/bom
 # Plugins
 shadow = "9.3.1" # https://github.com/GradleUp/shadow/releases
-git-version = "5.0.0" # https://github.com/palantir/gradle-git-version/releases
+git-semver = "0.19.0" # https://github.com/jmongard/Git.SemVersioning.Gradle/releases
 
 [libraries]
 com-alpsbte-alpslib-alpslib-hologram = { module = "com.alpsbte.alpslib:alpslib-hologram", version.ref = "com-alpsbte-alpslib-alpslib-hologram" }
@@ -41,5 +41,5 @@ org-mariadb-jdbc-mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java
 com-intellectualsites-bom-bom-newest = { module = "com.intellectualsites.bom:bom-newest", version.ref = "com-intellectualsites-bom-bom-newest" }
 
 [plugins]
-git-version = { id = "com.palantir.git-version", version.ref = "git-version" }
+git-semver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "git-semver" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
Closes #194. Partially addresses #149.

Sets up the full release lifecycle for Plot-System and replaces the hardcoded `"5.0.3"-<hash>-SNAPSHOT` version with one derived from git tags + conventional-commit history.

### Pipeline after this PR

1. **PR opened** → `build.yml` (existing) runs CI, no release side-effects.
2. **Push to `main`** → `release-draft.yml` (new) computes the next version via `./gradlew printVersion` and updates a single draft release via [release-drafter](https://github.com/release-drafter/release-drafter).
3. **Maintainer clicks Publish** on the draft → GitHub creates the tag.
4. **`release: published`** → `release.yml` (new) checks out the tag, builds, and attaches `build/libs/*.jar` to the release.

### Files

- `build.gradle.kts`, `gradle/libs.versions.toml` — swap `palantir/gradle-git-version` (5.0.0) for [`jmongard/git-semver-plugin`](https://github.com/jmongard/Git.SemVersioning.Gradle) (0.19.0); `version = semver.semVersion`.
- `.github/workflows/release-draft.yml` + `.github/release-drafter.yml` — maintain the draft release on every push to main.
- `.github/workflows/release.yml` — attach the shaded JAR on release publish.

### Versioning behavior

With the new plugin, conventional-commit prefixes drive the next version:

- `feat:` → minor bump
- `fix:` → patch bump
- `feat!:` / `BREAKING CHANGE:` → major bump
- `chore:` / `ci:` / `docs:` / `build:` → no bump

This PR's commits use `build:` and `ci:` so it does not bump the version on its own.

### Caveat

release-drafter rewrites the "What's Changed" section on every push to main, so manual edits inside that section are overwritten by the next push. Intended workflow: pause merging → polish the draft → publish. Splitting the body into auto/manual regions is doable as a follow-up if needed.

### Out of scope

- README badge swap and nightly.link Downloads section — separate PR per the discussion on #194.
- Branch name in version, maven publishing, Discord release announcements — deferred per the same discussion.

### Test plan

- [x] `./gradlew clean build` passes locally with the new plugin.
- [ ] After merge, `release-draft.yml` produces a draft visible on the [Releases](https://github.com/AlpsBTE/Plot-System/releases) page.
- [ ] Clicking Publish on the draft triggers `release.yml` and the release ends up with `PlotSystem-<version>.jar` attached.
