### PR TITLE
fix(schematics): 🐛 prevent schematic truncation for plots exceeding world height

### DIFF
--- a/src/main/java/com/alpsbte/plotsystem/core/system/plot/utils/PlotUtils.java
+++ b/src/main/java/com/alpsbte/plotsystem/core/system/plot/utils/PlotUtils.java
@@ -72,7 +72,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -207,7 +206,7 @@ public final class PlotUtils {
         }
 
         Polygonal2DRegion region = new Polygonal2DRegion(
-                BukkitAdapter.adapt(world),
+                null,
                 plot.getOutline(),
                 clipboard.getMinimumPoint().y(),
                 clipboard.getMaximumPoint().y()
@@ -259,14 +258,14 @@ public final class PlotUtils {
         // Load finished plot region as cuboid region
         if (!plot.getWorld().loadWorld()) return false;
         com.sk89q.worldedit.world.World world = new BukkitWorld(plot.getWorld().getBukkitWorld());
-        Polygonal2DRegion region = new Polygonal2DRegion(world, plotOutlines, cuboidRegion.getMinimumPoint().y(), cuboidRegion.getMaximumPoint().y());
+        Polygonal2DRegion region = new Polygonal2DRegion(null, plotOutlines, cuboidRegion.getMinimumPoint().y(), cuboidRegion.getMaximumPoint().y());
 
         // Copy and write finished plot clipboard to schematic
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try (Clipboard cb = new BlockArrayClipboard(region)) {
             cb.setOrigin(BlockVector3.at(plotCenter.x(), cuboidRegion.getMinimumY(), (double) plotCenter.z()));
 
-            ForwardExtentCopy forwardExtentCopy = new ForwardExtentCopy(Objects.requireNonNull(region.getWorld()), region, cb, region.getMinimumPoint());
+            ForwardExtentCopy forwardExtentCopy = new ForwardExtentCopy(world, region, cb, region.getMinimumPoint());
             Operations.complete(forwardExtentCopy);
 
             try (ClipboardWriter writer = AbstractPlot.CLIPBOARD_FORMAT.getWriter(outputStream)) {


### PR DESCRIPTION
**The Issue:**
Plots originating from coordinates above standard world height limits (e.g., Y=351 to Y=606 for Plot 944) were failing to generate correctly. This resulted in completely void schematics when loading outlines or saving completed plots.

**The Cause:**
When defining the `Polygonal2DRegion` for clipboard operations, passing the `BukkitWorld` object forced WorldEdit to aggressively clamp the region's Y-bounds to the world's max build height (typically Y=320). This caused high-altitude regions to collapse into a flattened 1-block height mapping (minY: 320, maxY: 320). During `ForwardExtentCopy`, the actual block data failed to map to this squashed dimension, resulting in empty outputs.

**The Fix:**
Replaced the `world` reference with `null` during the instantiation of `Polygonal2DRegion` inside `PlotUtils.getOutlinesSchematicBytes()` and `PlotUtils.savePlotAsSchematic()`. Omitting the world constraint forces WorldEdit to fallback to its global absolute limits (±30,000,000) instead of the local world bounds, fully preserving the plot's native schematic dimensions.