### PR TITLE
ci(release): add release pipeline and switch versioning to git-semver

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,15 +4,12 @@ tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: 'Features'
     labels:
-      - 'feature'
       - 'enhancement'
   - title: 'Bug Fixes'
     labels:
-      - 'fix'
       - 'bug'
   - title: 'Maintenance'
     labels:
-      - 'chore'
       - 'dependencies'
       - 'documentation'
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,27 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+categories:
+  - title: 'Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bug'
+  - title: 'Maintenance'
+    labels:
+      - 'chore'
+      - 'dependencies'
+      - 'documentation'
+
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+change-title-escapes: '\<*_&'
+
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Checkout PR merge commit
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
@@ -24,7 +24,7 @@ jobs:
 
       - name: Checkout main on push
         if: github.event_name == 'push'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -36,12 +36,12 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle Wrapper
         run: ./gradlew clean build
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Staging-Build
           path: build/libs

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -25,7 +25,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Compute next release version
         id: version
@@ -34,7 +34,7 @@ jobs:
           echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
 
       - name: Update release draft
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7
         with:
           version: ${{ steps.version.outputs.next }}
         env:

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -1,0 +1,41 @@
+name: Update Release Draft
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update-draft:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Compute next version
+        id: version
+        run: |
+          NEXT="$(./gradlew -q printVersion)"
+          echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
+
+      - name: Update release draft
+        uses: release-drafter/release-drafter@v6
+        with:
+          version: ${{ steps.version.outputs.next }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-draft.yml
+++ b/.github/workflows/release-draft.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Compute next version
+      - name: Compute next release version
         id: version
         run: |
-          NEXT="$(./gradlew -q printVersion)"
+          NEXT="$(./gradlew -q printNextReleaseVersion)"
           echo "next=${NEXT}" >> "$GITHUB_OUTPUT"
 
       - name: Update release draft

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -24,13 +24,13 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build with Gradle Wrapper
         run: ./gradlew clean build
 
       - name: Attach shaded JAR to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: build/libs/*.jar
           fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Attach Release Artifacts
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew clean build
+
+      - name: Attach shaded JAR to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: build/libs/*.jar
+          fail_on_unmatched_files: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/README.md
+++ b/README.md
@@ -111,6 +111,23 @@ dedicated to the Plot-System itself.</br>
 * Submitting a fix
 * Proposing new features
 
+### Commit Naming Conventions
+
+To keep our commit history clean and readable, please follow a naming convention for your commits by using one of the
+following prefixes (based on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)):
+
+* `feat:` - A new feature
+* `fix:` - A bug fix
+* `docs:` - Documentation only changes
+* `style:` - Changes that do not affect the meaning of the code (white-space, formatting, etc.)
+* `refactor:` - A code change that neither fixes a bug nor adds a feature
+* `perf:` - A code change that improves performance
+* `test:` - Adding missing tests or correcting existing tests
+* `chore:` - Changes to the build process or auxiliary tools and libraries
+
+If no recognized prefix is provided, the maintainers may ask you to revise your commit message, or they may squash and
+rename the commit with an appropriate prefix upon merging.
+
 # License
 Distributed under the MIT License. See `LICENSE` for more information.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,13 @@ tasks.jar {
     enabled = false // Disable the default jar task since we are using shadowJar
 }
 
+tasks.register("printNextReleaseVersion") {
+    val nextRelease = semver.version.toString().removeSuffix("-SNAPSHOT")
+    doLast {
+        println(nextRelease)
+    }
+}
+
 tasks.processResources {
     // work around IDEA-296490
     duplicatesStrategy = DuplicatesStrategy.INCLUDE

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    alias(libs.plugins.git.version)
+    alias(libs.plugins.git.semver)
     alias(libs.plugins.shadow)
 }
 
@@ -61,11 +61,8 @@ dependencies {
     compileOnly(libs.io.papermc.paper.paper.api)
 }
 
-val versionDetails: groovy.lang.Closure<com.palantir.gradle.gitversion.VersionDetails> by extra
-val details = versionDetails()
-
 group = "com.alpsbte"
-version = "5.0.3" + "-" + details.gitHash + "-SNAPSHOT"
+version = semver.semVersion
 description = "An easy to use building system for the BuildTheEarth project."
 java.sourceCompatibility = JavaVersion.VERSION_21
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ org-mariadb-jdbc-mariadb-java-client = "3.5.7" #  https://central.sonatype.com/a
 com-intellectualsites-bom-bom-newest = "1.55" # Ref: https://github.com/IntellectualSites/bom
 # Plugins
 shadow = "9.3.1" # https://github.com/GradleUp/shadow/releases
-git-version = "5.0.0" # https://github.com/palantir/gradle-git-version/releases
+git-semver = "0.19.0" # https://github.com/jmongard/Git.SemVersioning.Gradle/releases
 
 [libraries]
 com-alpsbte-alpslib-alpslib-hologram = { module = "com.alpsbte.alpslib:alpslib-hologram", version.ref = "com-alpsbte-alpslib-alpslib-hologram" }
@@ -41,5 +41,5 @@ org-mariadb-jdbc-mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java
 com-intellectualsites-bom-bom-newest = { module = "com.intellectualsites.bom:bom-newest", version.ref = "com-intellectualsites-bom-bom-newest" }
 
 [plugins]
-git-version = { id = "com.palantir.git-version", version.ref = "git-version" }
+git-semver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "git-semver" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }


### PR DESCRIPTION
Closes #194. Partially addresses #149 (the README overhaul will follow in a separate PR).

Sets up the full release lifecycle for Plot-System and replaces the hardcoded `"5.0.3"-<hash>-SNAPSHOT` version expression with one derived from git tags + conventional-commit history.

## New release flow

| Trigger | Workflow | What it does |
|---|---|---|
| PR opened / updated | `build.yml` *(existing, unchanged)* | Build + test, no release side-effects |
| Push to `main` | `release-draft.yml` *(new)* | Compute next clean version via gradle, maintain a single editable draft release with auto-generated notes |
| Maintainer clicks **Publish** on the draft | — | GitHub creates the tag |
| `release: published` | `release.yml` *(new)* | Build from the tag, attach the shaded JAR to the release |

## Changes

### Versioning
- `gradle/libs.versions.toml`: swap `palantir/gradle-git-version` (5.0.0) for [`jmongard/git-semver-plugin`](https://github.com/jmongard/Git.SemVersioning.Gradle) (0.19.0).
- `build.gradle.kts`: replace hardcoded version with `semver.semVersion`. Adds a `printNextReleaseVersion` helper task that returns the next clean version (stripped of the `-SNAPSHOT` suffix the plugin adds between tags). The task captures its value at configuration time so it stays compatible with the project's configuration cache.

### Draft release maintenance (new)
- `.github/workflows/release-draft.yml`: runs on push to `main`. Calls `./gradlew -q printNextReleaseVersion` and feeds the result to [`release-drafter/release-drafter@v6`](https://github.com/release-drafter/release-drafter).
- `.github/release-drafter.yml`: minimal config with three categories (Features, Bug Fixes, Maintenance) mapped to existing repo labels (`enhancement`, `bug`, `dependencies`, `documentation`). PRs without a matching label fall under the uncategorised list.

### Release artifact upload (new)
- `.github/workflows/release.yml`: runs on `release: published`, checks out the release tag, builds, and attaches `build/libs/*.jar` via `softprops/action-gh-release@v2`. Uses the default `GITHUB_TOKEN` with `contents: write` — no extra secrets required.

## Commit convention going forward

With the new semver plugin active, conventional-commit prefixes drive the next version bump:

| Prefix | Effect |
|---|---|
| `feat: …` | minor bump (5.0.2 → 5.1.0) |
| `fix: …` | patch bump (5.0.2 → 5.0.3) |
| `feat!:` or footer `BREAKING CHANGE:` | major bump |
| `build:` / `ci:` / `chore:` / `docs:` / `refactor:` / `test:` | no bump |

This PR's commits use `build(gradle):` and `ci(release):` so merging it does not bump the version on its own.

## Caveats / notes

- **Manual edits to the draft body are overwritten** on the next push to `main` (release-drafter regenerates the "What's Changed" section each run). Intended workflow: pause merging → polish the draft → publish. Splitting the body into auto/manual regions is doable as a follow-up if needed.
- **No "New Contributors" section.** release-drafter doesn't expose first-time contributors, and GitHub's native auto-generated notes (which do include that block) don't fit a maintained-draft workflow. Could be added later via an extra step that calls `gh api .../releases/generate-notes` and appends just that section.

## Out of scope (intentionally deferred)

- README badge swap + nightly.link Downloads section — separate PR per the discussion on #194.
- Branch name embedded in version — still being discussed (in-version vs full git metadata exposed via in-game command).
- Maven publishing — not needed until Plot-System exposes a public API.
- Discord release announcements from #149's checklist — separate work.

## Test plan

- [x] `./gradlew clean build` passes locally with the new plugin.
- [x] `./gradlew -q printNextReleaseVersion` returns the clean version (no `-SNAPSHOT`) and is configuration-cache compatible.
- [ ] After merge, `release-draft.yml` produces a draft visible on the [Releases](https://github.com/AlpsBTE/Plot-System/releases) page.
- [ ] Clicking Publish on the draft triggers `release.yml` and the resulting release has `PlotSystem-<version>.jar` attached.
