### PR TITLE
Support 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,9 @@ tasks.jar {
 }
 
 tasks.register("printNextReleaseVersion") {
-    val nextRelease = semver.version.toString().removeSuffix("-SNAPSHOT")
+    description = "Prints the next full release version"
+    group = "versioning"
+    val nextRelease = semver.version.removeSuffix("-SNAPSHOT")
     doLast {
         println(nextRelease)
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
     }
 
     maven {
-        url = uri("https://repo.fancyplugins.de/releases")
+        url = uri("https://maven.fancyspaces.net/fancynpcs/fi-releases")
     }
 
     maven {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,8 +63,6 @@ dependencies {
 
 group = "com.alpsbte"
 
-val rawVersion = semver.semVersion.toString()
-
 version = semver.semVersion.toString().let {
     if ("-SNAPSHOT" in it) it else semver.version // If it's a release (no .SNAPSHOT Suffix) use the version without additional metadata
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,10 @@ repositories {
     }
 }
 
+val paperNextEnabled = providers.gradleProperty("paperNext")
+    .map(String::toBoolean)
+    .orElse(false)
+
 dependencies {
     implementation(libs.com.alpsbte.canvas)
     implementation(libs.com.alpsbte.alpslib.alpslib.io)
@@ -59,6 +63,13 @@ dependencies {
     compileOnly(libs.li.cinnazeyy.langlibs.api)
     compileOnly(libs.commons.io.commons.io)
     compileOnly(libs.io.papermc.paper.paper.api)
+
+    if (paperNextEnabled.get()) {
+        constraints {
+            compileOnly("io.papermc.paper:paper-api:26.1.2.build.+")
+            compileOnly("com.github.decentsoftware-eu:decentholograms:2.10.0")
+        }
+    }
 }
 
 group = "com.alpsbte"
@@ -68,15 +79,6 @@ version = semver.semVersion.toString().let {
 }
 
 description = "An easy to use building system for the BuildTheEarth project."
-java.sourceCompatibility = JavaVersion.VERSION_21
-
-tasks.withType<JavaCompile> {
-    options.encoding = "UTF-8"
-}
-
-tasks.withType<Javadoc> {
-    options.encoding = "UTF-8"
-}
 
 tasks.shadowJar {
     archiveClassifier = ""
@@ -115,4 +117,38 @@ tasks.processResources {
             )
         }
     })
+}
+
+
+val targetJava = providers.gradleProperty("targetJava")
+    .map(String::toInt)
+    .orElse(21)
+
+java {
+    toolchain {
+        languageVersion.set(targetJava.map(JavaLanguageVersion::of))
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    options.release.set(targetJava)
+}
+
+tasks.withType<Javadoc>().configureEach {
+    options.encoding = "UTF-8"
+}
+
+tasks.register<GradleBuild>("buildPaperNext") {
+    group = "verification"
+    description = "Builds against Java 25 and the Paper-next dependency set"
+
+    tasks = listOf("clean", "build")
+
+    startParameter.projectProperties.putAll(
+        mapOf(
+            "paperNext" to "true",
+            "targetJava" to "25"
+        )
+    )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ com-github-fierioziy-particlenativeapi-particlenativeapi-plugin = "3.3.2"
 # Ref: https://github.com/IntellectualSites/bom
 com-intellectualsites-bom-bom-newest = "1.56"
 # https://maven.enginehub.org/repo/com/sk89q/worldguard/worldguard-bukkit/
-com-sk89q-worldguard-worldguard-bukkit = "7.1.0-SNAPSHOT"
+com-sk89q-worldguard-worldguard-bukkit = "7.0.17"
 # https://github.com/brettwooldridge/HikariCP/tags
 com-zaxxer-hikaricp = "7.0.2"
 # Provided by Minecraft (Libs folder)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,26 +1,47 @@
 # https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format
-
 [versions]
+#
 # Dependencies
-com-alpsbte-alpslib-alpslib-hologram = "1.1.+" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-hologram/
-com-alpsbte-alpslib-alpslib-io = "1.2.+" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-io/
-com-alpsbte-alpslib-alpslib-utils = "1.4.+" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-utils/
-com-alpsbte-canvas = "1.3" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/canvas/
-com-arcaniax-headdatabase-api = "1.3.+" # https://github.com/Arcaniax-Development/HeadDatabase-API/releases
-com-github-decentsoftware-eu-decentholograms = "2.9.9" # https://github.com/DecentSoftware-eu/DecentHolograms/releases # 2.10+ require java 25 (MC 26.1+ mainly)
-com-github-fierioziy-particlenativeapi-particlenativeapi-plugin = "3.3.2" # https://github.com/Fierioziy/ParticleNativeAPI/releases - we are stuck at v3 for now. Need to migrate some time or remove it
-multiverse-core = "5.5.2" # https://repo.onarandombox.com/#/multiverse-releases/org/mvplugins/multiverse/core/multiverse-core
-com-sk89q-worldguard-worldguard-bukkit = "7.0.+" # https://maven.enginehub.org/repo/com/sk89q/worldguard/worldguard-bukkit/
-com-zaxxer-hikaricp = "6.+" # https://github.com/brettwooldridge/HikariCP/tags
-commons-io-commons-io = "2.20.0" # Provided by Minecraft (Libs folder)
-de-oliver-fancynpcs = "2.9.2" # https://fancyspaces.net/spaces/fancynpcs/maven-repos/fi-releases/de.oliver:FancyNpcs
-io-papermc-paper-paper-api = "1.21.11-R0.1-SNAPSHOT" # https://artifactory.papermc.io/ui/native/universe/io/papermc/paper/paper-api/
-li-cinnazeyy-langlibs-api = "1.5.2" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/li/cinnazeyy/LangLibs-API/
-org-mariadb-jdbc-mariadb-java-client = "3.+" #  https://central.sonatype.com/artifact/org.mariadb.jdbc/mariadb-java-client
-com-intellectualsites-bom-bom-newest = "1.55" # Ref: https://github.com/IntellectualSites/bom
+#
+# https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-hologram/
+com-alpsbte-alpslib-alpslib-hologram = "1.1.3"
+# https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-io/
+com-alpsbte-alpslib-alpslib-io = "1.2.5"
+# https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-utils/
+com-alpsbte-alpslib-alpslib-utils = "1.4.6"
+# https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/canvas/
+com-alpsbte-canvas = "1.3"
+# https://github.com/Arcaniax-Development/HeadDatabase-API/releases
+com-arcaniax-headdatabase-api = "1.3.3-SNAPSHOT"
+# @pin https://github.com/DecentSoftware-eu/DecentHolograms/releases 2.10+ require java 25 (MC 26.1+ mainly)
+com-github-decentsoftware-eu-decentholograms = "2.9.9"
+# @pin https://github.com/Fierioziy/ParticleNativeAPI/releases - we are stuck at v3 for now. Need to migrate some time or remove it
+com-github-fierioziy-particlenativeapi-particlenativeapi-plugin = "3.3.2"
+# Ref: https://github.com/IntellectualSites/bom
+com-intellectualsites-bom-bom-newest = "1.56"
+# https://maven.enginehub.org/repo/com/sk89q/worldguard/worldguard-bukkit/
+com-sk89q-worldguard-worldguard-bukkit = "7.1.0-SNAPSHOT"
+# https://github.com/brettwooldridge/HikariCP/tags
+com-zaxxer-hikaricp = "7.0.2"
+# Provided by Minecraft (Libs folder)
+commons-io-commons-io = "2.22.0"
+# https://fancyspaces.net/spaces/fancynpcs/maven-repos/fi-releases/de.oliver:FancyNpcs
+de-oliver-fancynpcs = "2.9.2"
+# @pin https://artifactory.papermc.io/ui/native/universe/io/papermc/paper/paper-api/ 26.1+ requires java 25
+io-papermc-paper-paper-api = "1.21.11-R0.1-SNAPSHOT"
+# https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/li/cinnazeyy/LangLibs-API/
+li-cinnazeyy-langlibs-api = "1.5.2"
+# https://repo.onarandombox.com/#/multiverse-releases/org/mvplugins/multiverse/core/multiverse-core
+multiverse-core = "5.7.0"
+#  https://central.sonatype.com/artifact/org.mariadb.jdbc/mariadb-java-client
+org-mariadb-jdbc-mariadb-java-client = "3.6.0-SNAPSHOT"
+#
 # Plugins
-shadow = "9.+" # https://github.com/GradleUp/shadow/releases
-git-semver = "0.+" # https://github.com/jmongard/Git.SemVersioning.Gradle/releases
+#
+# https://github.com/jmongard/Git.SemVersioning.Gradle/releases
+git-semver = "0.19.1"
+# https://github.com/GradleUp/shadow/releases
+shadow = "9.4.2"
 
 [libraries]
 com-alpsbte-alpslib-alpslib-hologram = { module = "com.alpsbte.alpslib:alpslib-hologram", version.ref = "com-alpsbte-alpslib-alpslib-hologram" }
@@ -30,15 +51,15 @@ com-alpsbte-canvas = { module = "com.alpsbte:canvas", version.ref = "com-alpsbte
 com-arcaniax-headdatabase-api = { module = "com.arcaniax:HeadDatabase-API", version.ref = "com-arcaniax-headdatabase-api" }
 com-github-decentsoftware-eu-decentholograms = { module = "com.github.decentsoftware-eu:decentholograms", version.ref = "com-github-decentsoftware-eu-decentholograms" }
 com-github-fierioziy-particlenativeapi-particlenativeapi-plugin = { module = "com.github.fierioziy.particlenativeapi:ParticleNativeAPI-plugin", version.ref = "com-github-fierioziy-particlenativeapi-particlenativeapi-plugin" }
-multiverse-core = { module = "org.mvplugins.multiverse.core:multiverse-core", version.ref = "multiverse-core" }
+com-intellectualsites-bom-bom-newest = { module = "com.intellectualsites.bom:bom-newest", version.ref = "com-intellectualsites-bom-bom-newest" }
 com-sk89q-worldguard-worldguard-bukkit = { module = "com.sk89q.worldguard:worldguard-bukkit", version.ref = "com-sk89q-worldguard-worldguard-bukkit" }
 com-zaxxer-hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "com-zaxxer-hikaricp" }
 commons-io-commons-io = { module = "commons-io:commons-io", version.ref = "commons-io-commons-io" }
 de-oliver-fancynpcs = { module = "de.oliver:FancyNpcs", version.ref = "de-oliver-fancynpcs" }
 io-papermc-paper-paper-api = { module = "io.papermc.paper:paper-api", version.ref = "io-papermc-paper-paper-api" }
 li-cinnazeyy-langlibs-api = { module = "li.cinnazeyy:LangLibs-API", version.ref = "li-cinnazeyy-langlibs-api" }
+multiverse-core = { module = "org.mvplugins.multiverse.core:multiverse-core", version.ref = "multiverse-core" }
 org-mariadb-jdbc-mariadb-java-client = { module = "org.mariadb.jdbc:mariadb-java-client", version.ref = "org-mariadb-jdbc-mariadb-java-client" }
-com-intellectualsites-bom-bom-newest = { module = "com.intellectualsites.bom:bom-newest", version.ref = "com-intellectualsites-bom-bom-newest" }
 
 [plugins]
 git-semver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "git-semver" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,25 +2,25 @@
 
 [versions]
 # Dependencies
-com-alpsbte-alpslib-alpslib-hologram = "1.1.2" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-hologram/
-com-alpsbte-alpslib-alpslib-io = "1.2.4" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-io/
-com-alpsbte-alpslib-alpslib-utils = "1.4.4" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-utils/
+com-alpsbte-alpslib-alpslib-hologram = "1.1.+" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-hologram/
+com-alpsbte-alpslib-alpslib-io = "1.2.+" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-io/
+com-alpsbte-alpslib-alpslib-utils = "1.4.+" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/alpslib/alpslib-utils/
 com-alpsbte-canvas = "1.3" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/com/alpsbte/canvas/
-com-arcaniax-headdatabase-api = "1.3.2" # https://github.com/Arcaniax-Development/HeadDatabase-API/releases
-com-github-decentsoftware-eu-decentholograms = "2.9.9" # https://github.com/DecentSoftware-eu/DecentHolograms/releases
+com-arcaniax-headdatabase-api = "1.3.+" # https://github.com/Arcaniax-Development/HeadDatabase-API/releases
+com-github-decentsoftware-eu-decentholograms = "2.9.9" # https://github.com/DecentSoftware-eu/DecentHolograms/releases # 2.10+ require java 25 (MC 26.1+ mainly)
 com-github-fierioziy-particlenativeapi-particlenativeapi-plugin = "3.3.2" # https://github.com/Fierioziy/ParticleNativeAPI/releases - we are stuck at v3 for now. Need to migrate some time or remove it
 multiverse-core = "5.5.2" # https://repo.onarandombox.com/#/multiverse-releases/org/mvplugins/multiverse/core/multiverse-core
-com-sk89q-worldguard-worldguard-bukkit = "7.0.15" # https://maven.enginehub.org/repo/com/sk89q/worldguard/worldguard-bukkit/
-com-zaxxer-hikaricp = "6.3.0" # https://github.com/brettwooldridge/HikariCP/tags
+com-sk89q-worldguard-worldguard-bukkit = "7.0.+" # https://maven.enginehub.org/repo/com/sk89q/worldguard/worldguard-bukkit/
+com-zaxxer-hikaricp = "6.+" # https://github.com/brettwooldridge/HikariCP/tags
 commons-io-commons-io = "2.20.0" # Provided by Minecraft (Libs folder)
 de-oliver-fancynpcs = "2.9.2" # https://fancyspaces.net/spaces/fancynpcs/maven-repos/fi-releases/de.oliver:FancyNpcs
 io-papermc-paper-paper-api = "1.21.11-R0.1-SNAPSHOT" # https://artifactory.papermc.io/ui/native/universe/io/papermc/paper/paper-api/
 li-cinnazeyy-langlibs-api = "1.5.2" # https://mvn.alps-bte.com/service/rest/repository/browse/alps-bte/li/cinnazeyy/LangLibs-API/
-org-mariadb-jdbc-mariadb-java-client = "3.5.7" #  https://central.sonatype.com/artifact/org.mariadb.jdbc/mariadb-java-client
+org-mariadb-jdbc-mariadb-java-client = "3.+" #  https://central.sonatype.com/artifact/org.mariadb.jdbc/mariadb-java-client
 com-intellectualsites-bom-bom-newest = "1.55" # Ref: https://github.com/IntellectualSites/bom
 # Plugins
-shadow = "9.3.1" # https://github.com/GradleUp/shadow/releases
-git-semver = "0.19.0" # https://github.com/jmongard/Git.SemVersioning.Gradle/releases
+shadow = "9.+" # https://github.com/GradleUp/shadow/releases
+git-semver = "0.+" # https://github.com/jmongard/Git.SemVersioning.Gradle/releases
 
 [libraries]
 com-alpsbte-alpslib-alpslib-hologram = { module = "com.alpsbte.alpslib:alpslib-hologram", version.ref = "com-alpsbte-alpslib-alpslib-hologram" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
build(gradle): update dependencies to flexible versions and upgrade Gradle to 9.5.1

Main dependency which needed an update was XSeries in the alpslib, that errored out otherwise. 

We don't want to update to Java 25 / Minecraft 26.1.2 yet, to ensure we have no breaking changes i made a compatibility build- 